### PR TITLE
Add Linear stimulus support and update RelativeLinear to enable ramping

### DIFF
--- a/bluecellulab/cell/injector.py
+++ b/bluecellulab/cell/injector.py
@@ -262,8 +262,18 @@ class InjectableMixin:
     def add_replay_relativelinear(self, stimulus):
         """Add a relative linear stimulus."""
         tstim = neuron.h.TStim(0.5, sec=self.soma)
-        amp = stimulus.percent_start / 100.0 * self.threshold
-        tstim.pulse(stimulus.delay, stimulus.duration, amp)
+        amp_start = stimulus.percent_start / 100.0 * self.threshold
+        amp_end = stimulus.percent_end / 100.0 * self.threshold
+
+        tstim.ramp(
+            0.0,
+            stimulus.delay,       # Time when the ramp starts
+            amp_start,      # Initial amplitude (amp_start)
+            amp_end,       # Final amplitude (amp_end)
+            stimulus.duration,    # Duration of the ramp
+            0.0,
+            0.0
+        )
         self.persistent.append(tstim)
 
         return tstim

--- a/bluecellulab/cell/injector.py
+++ b/bluecellulab/cell/injector.py
@@ -263,7 +263,7 @@ class InjectableMixin:
 
     def add_replay_linear(self, stimulus: Linear):
         """Add a linear stimulus."""
-        tstim = neuron.h.TStim(0.5, sec=self.soma)
+        tstim = neuron.h.TStim(0.5, sec=self.soma)  # type: ignore
 
         tstim.ramp(
             0.0,
@@ -274,15 +274,15 @@ class InjectableMixin:
             0.0,
             0.0
         )
-        self.persistent.append(tstim)
+        self.persistent.append(tstim)  # type: ignore
 
         return tstim
 
     def add_replay_relativelinear(self, stimulus: RelativeLinear):
         """Add a relative linear stimulus."""
-        tstim = neuron.h.TStim(0.5, sec=self.soma)
-        amp_start = stimulus.percent_start / 100.0 * self.threshold
-        amp_end = stimulus.percent_end / 100.0 * self.threshold
+        tstim = neuron.h.TStim(0.5, sec=self.soma)  # type: ignore
+        amp_start = stimulus.percent_start / 100.0 * self.threshold  # type: ignore
+        amp_end = stimulus.percent_end / 100.0 * self.threshold  # type: ignore
 
         tstim.ramp(
             0.0,
@@ -293,7 +293,7 @@ class InjectableMixin:
             0.0,
             0.0
         )
-        self.persistent.append(tstim)
+        self.persistent.append(tstim)  # type: ignore
 
         return tstim
 

--- a/bluecellulab/cell/injector.py
+++ b/bluecellulab/cell/injector.py
@@ -263,20 +263,13 @@ class InjectableMixin:
 
     def add_replay_linear(self, stimulus: Linear):
         """Add a linear stimulus."""
-        tstim = neuron.h.TStim(0.5, sec=self.soma)  # type: ignore
 
-        tstim.ramp(
-            0.0,
-            stimulus.delay,       # Time when the ramp starts
-            stimulus.amp_start,      # Initial amplitude (amp_start)
-            stimulus.amp_end,       # Final amplitude (amp_end)
-            stimulus.duration,    # Duration of the ramp
-            0.0,
-            0.0
+        return self.add_ramp(
+            stimulus.delay,
+            stimulus.delay + stimulus.duration,
+            stimulus.amp_start,
+            stimulus.amp_end
         )
-        self.persistent.append(tstim)  # type: ignore
-
-        return tstim
 
     def add_replay_relativelinear(self, stimulus: RelativeLinear):
         """Add a relative linear stimulus."""

--- a/bluecellulab/cell/injector.py
+++ b/bluecellulab/cell/injector.py
@@ -259,6 +259,23 @@ class InjectableMixin:
         self.persistent.append(tstim)  # type: ignore
         return tstim
 
+    def add_replay_linear(self, stimulus):
+        """Add a linear stimulus."""
+        tstim = neuron.h.TStim(0.5, sec=self.soma)
+
+        tstim.ramp(
+            0.0,
+            stimulus.delay,       # Time when the ramp starts
+            stimulus.amp_start,      # Initial amplitude (amp_start)
+            stimulus.amp_end,       # Final amplitude (amp_end)
+            stimulus.duration,    # Duration of the ramp
+            0.0,
+            0.0
+        )
+        self.persistent.append(tstim)
+
+        return tstim
+
     def add_replay_relativelinear(self, stimulus):
         """Add a relative linear stimulus."""
         tstim = neuron.h.TStim(0.5, sec=self.soma)

--- a/bluecellulab/cell/injector.py
+++ b/bluecellulab/cell/injector.py
@@ -30,6 +30,8 @@ from bluecellulab.exceptions import BluecellulabError
 from bluecellulab.rngsettings import RNGSettings
 from bluecellulab.stimulus.circuit_stimulus_definitions import (
     ClampMode,
+    Linear,
+    RelativeLinear,
     Hyperpolarizing,
     Noise,
     OrnsteinUhlenbeck,
@@ -259,7 +261,7 @@ class InjectableMixin:
         self.persistent.append(tstim)  # type: ignore
         return tstim
 
-    def add_replay_linear(self, stimulus):
+    def add_replay_linear(self, stimulus: Linear):
         """Add a linear stimulus."""
         tstim = neuron.h.TStim(0.5, sec=self.soma)
 
@@ -276,7 +278,7 @@ class InjectableMixin:
 
         return tstim
 
-    def add_replay_relativelinear(self, stimulus):
+    def add_replay_relativelinear(self, stimulus: RelativeLinear):
         """Add a relative linear stimulus."""
         tstim = neuron.h.TStim(0.5, sec=self.soma)
         amp_start = stimulus.percent_start / 100.0 * self.threshold

--- a/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
+++ b/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
@@ -152,8 +152,9 @@ class SonataCircuitAccess:
 
                 # make multiindex
                 synapses = synapses.reset_index(drop=True)
+                synapse_ids = list(synapses.index)
                 synapses.index = pd.MultiIndex.from_tuples(
-                    zip([edge_population_name] * len(synapses), synapses.index),
+                    [(edge_population_name, syn_id) for syn_id in synapse_ids],
                     names=["edge_name", "synapse_id"],
                 )
 

--- a/bluecellulab/circuit_simulation.py
+++ b/bluecellulab/circuit_simulation.py
@@ -139,6 +139,7 @@ class CircuitSimulation:
         pre_spike_trains: None | dict[tuple[str, int], Iterable] | dict[int, Iterable] = None,
         add_shotnoise_stimuli: bool = False,
         add_ornstein_uhlenbeck_stimuli: bool = False,
+        add_linear_stimuli: bool = False,
     ):
         """Instantiate a list of cells.
 
@@ -209,6 +210,11 @@ class CircuitSimulation:
                             of the simulation config,
                             Setting add_stimuli=True,
                             will automatically set this option to True.
+        add_linear_stimuli : Process the 'linear' stimuli
+                                blocks of the simulation config.
+                                Setting add_stimuli=True,
+                                will automatically set this option to
+                                True.
         """
         if not isinstance(cells, Iterable) or isinstance(cells, tuple):
             cells = [cells]
@@ -267,20 +273,23 @@ class CircuitSimulation:
             add_pulse_stimuli = True
             add_shotnoise_stimuli = True
             add_ornstein_uhlenbeck_stimuli = True
+            add_linear_stimuli = True
 
         if add_noise_stimuli or \
                 add_hyperpolarizing_stimuli or \
                 add_pulse_stimuli or \
                 add_relativelinear_stimuli or \
                 add_shotnoise_stimuli or \
-                add_ornstein_uhlenbeck_stimuli:
+                add_ornstein_uhlenbeck_stimuli or \
+                add_linear_stimuli:
             self._add_stimuli(
                 add_noise_stimuli=add_noise_stimuli,
                 add_hyperpolarizing_stimuli=add_hyperpolarizing_stimuli,
                 add_relativelinear_stimuli=add_relativelinear_stimuli,
                 add_pulse_stimuli=add_pulse_stimuli,
                 add_shotnoise_stimuli=add_shotnoise_stimuli,
-                add_ornstein_uhlenbeck_stimuli=add_ornstein_uhlenbeck_stimuli
+                add_ornstein_uhlenbeck_stimuli=add_ornstein_uhlenbeck_stimuli,
+                add_linear_stimuli=add_linear_stimuli
             )
 
     def _add_stimuli(self, add_noise_stimuli=False,
@@ -288,7 +297,8 @@ class CircuitSimulation:
                      add_relativelinear_stimuli=False,
                      add_pulse_stimuli=False,
                      add_shotnoise_stimuli=False,
-                     add_ornstein_uhlenbeck_stimuli=False
+                     add_ornstein_uhlenbeck_stimuli=False,
+                     add_linear_stimuli=False
                      ):
         """Instantiate all the stimuli."""
         stimuli_entries = self.circuit_access.config.get_all_stimuli_entries()
@@ -316,6 +326,9 @@ class CircuitSimulation:
                 elif isinstance(stimulus, circuit_stimulus_definitions.Pulse):
                     if add_pulse_stimuli:
                         self.cells[cell_id].add_pulse(stimulus)
+                elif isinstance(stimulus, circuit_stimulus_definitions.Linear):
+                    if add_linear_stimuli:
+                        self.cells[cell_id].add_replay_linear(stimulus)
                 elif isinstance(stimulus, circuit_stimulus_definitions.RelativeLinear):
                     if add_relativelinear_stimuli:
                         self.cells[cell_id].add_replay_relativelinear(stimulus)

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -141,6 +141,7 @@ class Stimulus:
                 delay=stimulus_entry["Delay"],
                 duration=stimulus_entry["Duration"],
                 percent_start=stimulus_entry["PercentStart"],
+                percent_end=stimulus_entry["PercentEnd"],
             )
         elif pattern == Pattern.SYNAPSE_REPLAY:
             warnings.warn("Ignoring syanpse replay stimulus as it is not supported")
@@ -236,6 +237,7 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 percent_start=stimulus_entry["percent_start"],
+                percent_end=stimulus_entry["percent_end"],
             )
         elif pattern == Pattern.SYNAPSE_REPLAY:
             return SynapseReplay(
@@ -325,6 +327,7 @@ class Pulse(Stimulus):
 @dataclass(frozen=True, config=dict(extra="forbid"))
 class RelativeLinear(Stimulus):
     percent_start: float
+    percent_end: float
 
 
 @dataclass(frozen=True, config=dict(extra="forbid"))

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -83,6 +83,8 @@ class Pattern(Enum):
             return Pattern.HYPERPOLARIZING
         elif pattern == "pulse":
             return Pattern.PULSE
+        elif pattern == "linear":
+            return Pattern.LINEAR
         elif pattern == "relative_linear":
             return Pattern.RELATIVE_LINEAR
         elif pattern == "synapse_replay":
@@ -244,11 +246,11 @@ class Stimulus:
             )
         elif pattern == Pattern.LINEAR:
             return Linear(
-                target=stimulus_entry["Target"],
-                delay=stimulus_entry["Delay"],
-                duration=stimulus_entry["Duration"],
-                amp_start=stimulus_entry["AmpStart"],
-                amp_end=stimulus_entry["AmpEnd"],
+                target=stimulus_entry["node_set"],
+                delay=stimulus_entry["delay"],
+                duration=stimulus_entry["duration"],
+                amp_start=stimulus_entry["amp_start"],
+                amp_end=stimulus_entry["amp_end"],
             )
         elif pattern == Pattern.RELATIVE_LINEAR:
             return RelativeLinear(

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -58,8 +58,6 @@ class Pattern(Enum):
             return Pattern.HYPERPOLARIZING
         elif pattern == "Pulse":
             return Pattern.PULSE
-        elif pattern == "Linear":
-            return Pattern.LINEAR
         elif pattern == "RelativeLinear":
             return Pattern.RELATIVE_LINEAR
         elif pattern == "SynapseReplay":
@@ -139,14 +137,6 @@ class Stimulus:
                 amp_start=stimulus_entry["AmpStart"],
                 width=stimulus_entry["Width"],
                 frequency=stimulus_entry["Frequency"],
-            )
-        elif pattern == Pattern.LINEAR:
-            return Linear(
-                target=stimulus_entry["Target"],
-                delay=stimulus_entry["Delay"],
-                duration=stimulus_entry["Duration"],
-                amp_start=stimulus_entry["AmpStart"],
-                amp_end=stimulus_entry["AmpEnd"],
             )
         elif pattern == Pattern.RELATIVE_LINEAR:
             return RelativeLinear(

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -42,6 +42,7 @@ class Pattern(Enum):
     NOISE = "noise"
     HYPERPOLARIZING = "hyperpolarizing"
     PULSE = "pulse"
+    LINEAR = "linear"
     RELATIVE_LINEAR = "relative_linear"
     SYNAPSE_REPLAY = "synapse_replay"
     SHOT_NOISE = "shot_noise"
@@ -57,6 +58,8 @@ class Pattern(Enum):
             return Pattern.HYPERPOLARIZING
         elif pattern == "Pulse":
             return Pattern.PULSE
+        elif pattern == "Linear":
+            return Pattern.LINEAR
         elif pattern == "RelativeLinear":
             return Pattern.RELATIVE_LINEAR
         elif pattern == "SynapseReplay":
@@ -134,6 +137,14 @@ class Stimulus:
                 amp_start=stimulus_entry["AmpStart"],
                 width=stimulus_entry["Width"],
                 frequency=stimulus_entry["Frequency"],
+            )
+        elif pattern == Pattern.LINEAR:
+            return Linear(
+                target=stimulus_entry["Target"],
+                delay=stimulus_entry["Delay"],
+                duration=stimulus_entry["Duration"],
+                amp_start=stimulus_entry["AmpStart"],
+                amp_end=stimulus_entry["AmpEnd"],
             )
         elif pattern == Pattern.RELATIVE_LINEAR:
             return RelativeLinear(
@@ -231,6 +242,14 @@ class Stimulus:
                 width=stimulus_entry["width"],
                 frequency=stimulus_entry["frequency"],
             )
+        elif pattern == Pattern.LINEAR:
+            return Linear(
+                target=stimulus_entry["Target"],
+                delay=stimulus_entry["Delay"],
+                duration=stimulus_entry["Duration"],
+                amp_start=stimulus_entry["AmpStart"],
+                amp_end=stimulus_entry["AmpEnd"],
+            )
         elif pattern == Pattern.RELATIVE_LINEAR:
             return RelativeLinear(
                 target=stimulus_entry["node_set"],
@@ -322,6 +341,12 @@ class Pulse(Stimulus):
     amp_start: float
     width: float
     frequency: float
+
+
+@dataclass(frozen=True, config=dict(extra="forbid"))
+class Linear(Stimulus):
+    amp_start: float
+    amp_end: float
 
 
 @dataclass(frozen=True, config=dict(extra="forbid"))

--- a/tests/examples/sonata_unit_test_sims/condition_parameters/simulation_config_many_inputs.json
+++ b/tests/examples/sonata_unit_test_sims/condition_parameters/simulation_config_many_inputs.json
@@ -35,6 +35,15 @@
       "spikes_sort_order": "by_time"
     },
     "inputs": {
+      "Threshold":{
+        "module": "noise",
+        "mean_percent": 200,
+        "variance": 0.001,
+        "delay": 10.0,
+        "duration": 20.0,
+        "input_type": "current_clamp",
+        "node_set": "Mosaic_A"
+      },
       "hypamp_mosaic": {
         "module": "hyperpolarizing",
         "input_type": "current_clamp",
@@ -42,12 +51,78 @@
         "duration": 50.0,
         "node_set": "Mosaic_A"
       },
-      "Threshold":{
-        "module": "noise",
-        "mean_percent": 200,
-        "variance": 0.001,
+      "Pulse":{
+        "module": "pulse",
         "delay": 10.0,
         "duration": 20.0,
+        "amp_start": 0.1,
+        "width": 25,
+        "frequency": 10,
+        "input_type": "current_clamp",
+        "node_set": "Mosaic_A"
+      },
+      "Linear":{
+        "module": "linear",
+        "delay": 10.0,
+        "duration": 20.0,
+        "amp_start": 0.1,
+        "amp_end": 0.4,
+        "input_type": "current_clamp",
+        "node_set": "Mosaic_A"
+      },
+      "RelativeLinear":{
+        "module": "relative_linear",
+        "delay": 10.0,
+        "duration": 20.0,
+        "percent_start": 50,
+        "percent_end": 100,
+        "input_type": "current_clamp",
+        "node_set": "Mosaic_A"
+      },
+      "ShotNoise":{
+        "module": "shot_noise",
+        "delay": 10.0,
+        "duration": 20.0,
+        "rise_time": 2,
+        "decay_time": 5,
+        "rate": 10.0,
+        "amp_mean": 0.1,
+        "amp_var": 0.02,
+        "random_seed": 42,
+        "input_type": "current_clamp",
+        "node_set": "Mosaic_A"
+      },
+      "RelativeShotNoise":{
+        "module": "relative_shot_noise",
+        "delay": 10.0,
+        "duration": 20.0,
+        "rise_time": 2,
+        "decay_time": 5,
+        "mean_percent": 50,
+        "sd_percent": 10,
+        "random_seed": 42,
+        "input_type": "current_clamp",
+        "node_set": "Mosaic_A"
+      },
+      "OrnsteinUhlenbeck":{
+        "module": "ornstein_uhlenbeck",
+        "delay": 10.0,
+        "duration": 20.0,
+        "tau": 5,
+        "sigma": 0.1,
+        "mean": 0,
+        "random_seed": 42,
+        "input_type": "current_clamp",
+        "node_set": "Mosaic_A"
+      },
+      "RelativeOrnsteinUhlenbeck":{
+        "module": "relative_ornstein_uhlenbeck",
+        "delay": 10.0,
+        "duration": 20.0,
+        "tau": 5,
+        "sd_percent": 10,
+        "mean_percent": 50,
+        "random_seed": 42,
         "input_type": "current_clamp",
         "node_set": "Mosaic_A"
       }
@@ -63,7 +138,6 @@
         "sections": "soma",
         "file_name": "soma",
         "compartments": "center"
-      } 
+      }
     }
   }
-  

--- a/tests/test_cell/test_injector.py
+++ b/tests/test_cell/test_injector.py
@@ -216,12 +216,25 @@ class TestInjector:
 
     def test_add_replay_relativelinear(self):
         """Unit test for add_replay_relativelinear."""
+
+        # If percent_start and percent_end are equal, the stimulus behaves like a step
         stimulus = RelativeLinear(
             target="single-cell",
-            delay=4, duration=20, percent_start=60)
+            delay=4, duration=20, percent_start=60, percent_end=60)
         tstim = self.cell.add_replay_relativelinear(stimulus)
-        assert tstim.stim.to_python() == [0.0, 0.1104372, 0.1104372, 0.0, 0.0]
-        assert tstim.tvec.to_python() == [4.0, 4.0, 24.0, 24.0, 24.0]
+
+        percent_60 = 0.1104372  # Amplitude at 60%
+        assert tstim.stim.to_python() == [0.0, 0.0, percent_60, percent_60, 0.0, 0.0]
+        assert tstim.tvec.to_python() == [0.0, 4.0, 4.0, 24.0, 24.0, 24.0]
+
+        # ramp from 60% to 100%
+        stimulus = RelativeLinear(
+            target="single-cell",
+            delay=0, duration=20, percent_start=60, percent_end=100)
+        tstim = self.cell.add_replay_relativelinear(stimulus)
+        percent_100 = (100 / 60) * percent_60
+        assert tstim.stim.to_python() == [0.0, 0.0, percent_60, percent_100, 0.0, 0.0]
+        assert tstim.tvec.to_python() == [0.0, 0.0, 0.0, 20.0, 20.0, 20.0]
 
     def test_get_ornstein_uhlenbeck_rand(self):
         """Unit test to check RNG generated for ornstein_uhlenbeck."""

--- a/tests/test_cell/test_injector.py
+++ b/tests/test_cell/test_injector.py
@@ -30,6 +30,7 @@ from bluecellulab.stimulus.circuit_stimulus_definitions import (
     Pulse,
     Noise,
     Hyperpolarizing,
+    Linear,
     RelativeLinear,
     OrnsteinUhlenbeck,
     RelativeOrnsteinUhlenbeck,
@@ -213,6 +214,24 @@ class TestInjector:
         with pytest.raises(BluecellulabError):
             self.cell.hypamp = None
             self.cell.add_replay_hypamp(stimulus)
+
+    def test_add_replay_linear(self):
+        """Unit test for add_replay_linear."""
+
+        amp_start = 0.1104372
+        stimulus = Linear(
+            target="single-cell",
+            delay=4, duration=20, amp_start=amp_start, amp_end=amp_start)
+        tstim = self.cell.add_replay_linear(stimulus)
+        assert tstim.stim.to_python() == [0.0, 0.0, amp_start, amp_start, 0.0, 0.0]
+        assert tstim.tvec.to_python() == [0.0, 4.0, 4.0, 24.0, 24.0, 24.0]
+
+        stimulus = Linear(
+            target="single-cell",
+            delay=0, duration=10, amp_start=amp_start, amp_end=0.5)
+        tstim = self.cell.add_replay_linear(stimulus)
+        assert tstim.stim.to_python() == [0.0, 0.0, amp_start, 0.5, 0.0, 0.0]
+        assert tstim.tvec.to_python() == [0.0, 0.0, 0.0, 10.0, 10.0, 10.0]
 
     def test_add_replay_relativelinear(self):
         """Unit test for add_replay_relativelinear."""

--- a/tests/test_circuit/test_simulation_config.py
+++ b/tests/test_circuit/test_simulation_config.py
@@ -25,7 +25,7 @@ from bluecellulab.circuit.config.sections import (
     ConnectionOverrides,
     MechanismConditions,
 )
-from bluecellulab.stimulus.circuit_stimulus_definitions import Noise, Hyperpolarizing
+from bluecellulab.stimulus.circuit_stimulus_definitions import Noise, Hyperpolarizing, Linear, Pulse, RelativeLinear, ShotNoise, RelativeShotNoise, OrnsteinUhlenbeck, RelativeOrnsteinUhlenbeck
 from tests.helpers.os_utils import cwd
 
 
@@ -74,10 +74,24 @@ def test_get_all_stimuli_entries():
     sim = SonataSimulationConfig(multi_input_conf_path)
     noise_stim = Noise("Mosaic_A", 10.0, 20.0, 200.0, 0.001)
     hyper_stim = Hyperpolarizing("Mosaic_A", 0.0, 50.0)
+    pulse_stim = Pulse("Mosaic_A", 10.0, 20.0, 0.1, 25, 10)
+    linear_stim = Linear("Mosaic_A", 10.0, 20.0, 0.1, 0.4)
+    relative_linear_stim = RelativeLinear("Mosaic_A", 10.0, 20.0, 50, 100)
+    shot_noise_stim = ShotNoise("Mosaic_A", 10.0, 20, 2, 5, 10, 0.1, 0.02, 0.25, 42)
+    relative_shot_noise_stim = RelativeShotNoise("Mosaic_A", 10.0, 20, 2, 5, 50, 10, 0.5, 0.25, 42)
+    ornstein_uhlenbeck_stim = OrnsteinUhlenbeck("Mosaic_A", 10.0, 20.0, 5, 0.1, 0, 0.25, 42)
+    relative_ornstein_uhlenbeck_stim = RelativeOrnsteinUhlenbeck("Mosaic_A", 10.0, 20.0, 5, 50, 10, 0.25, 42)
     entries = sim.get_all_stimuli_entries()
-    assert len(entries) == 2
-    assert entries[0] == noise_stim
-    assert entries[1] == hyper_stim
+    assert len(entries) == 9
+    assert entries[0] == linear_stim
+    assert entries[1] == ornstein_uhlenbeck_stim
+    assert entries[2] == pulse_stim
+    assert entries[3] == relative_linear_stim
+    assert entries[4] == relative_ornstein_uhlenbeck_stim
+    assert entries[5] == relative_shot_noise_stim
+    assert entries[6] == shot_noise_stim
+    assert entries[7] == noise_stim
+    assert entries[8] == hyper_stim
 
 
 def test_condition_parameters():

--- a/tests/test_stimulus/test_circuit_stimulus_definitions.py
+++ b/tests/test_stimulus/test_circuit_stimulus_definitions.py
@@ -1,4 +1,5 @@
 # Copyright 2023-2024 Blue Brain Project / EPFL
+# Copyright 2025 Open Brain Institute
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,19 +12,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for the stimuli module."""
 
-from pydantic import ValidationError
 import pytest
-from bluecellulab.stimulus.circuit_stimulus_definitions import SynapseReplay
+from bluecellulab.stimulus.circuit_stimulus_definitions import Pattern
 
 
-def test_synapse_replay_validator():
-    """Assures synapse replay's validator fails."""
-    with pytest.raises(ValidationError):
-        _ = SynapseReplay(
-            target="target1",
-            delay=0,
-            duration=3000,
-            spike_file="file_that_does_not_exist.dat",
-        )
+def test_pattern_from_sonata_valid():
+    """Test valid mappings from SONATA strings to Pattern enum values."""
+    valid_patterns = {
+        "noise": Pattern.NOISE,
+        "hyperpolarizing": Pattern.HYPERPOLARIZING,
+        "pulse": Pattern.PULSE,
+        "linear": Pattern.LINEAR,
+        "relative_linear": Pattern.RELATIVE_LINEAR,
+        "synapse_replay": Pattern.SYNAPSE_REPLAY,
+        "shot_noise": Pattern.SHOT_NOISE,
+        "relative_shot_noise": Pattern.RELATIVE_SHOT_NOISE,
+        "ornstein_uhlenbeck": Pattern.ORNSTEIN_UHLENBECK,
+        "relative_ornstein_uhlenbeck": Pattern.RELATIVE_ORNSTEIN_UHLENBECK,
+    }
+
+    for sonata_pattern, expected_enum in valid_patterns.items():
+        assert Pattern.from_sonata(sonata_pattern) == expected_enum
+
+
+def test_pattern_from_sonata_invalid():
+    """Test that an invalid pattern raises a ValueError."""
+    with pytest.raises(ValueError, match="Unknown pattern unknown_pattern"):
+        Pattern.from_sonata("unknown_pattern")


### PR DESCRIPTION
- Add Linear stimulus support in circuit simulation
- Update RelativeLinear to support ramping behavior. BlueCelluLab's RelativeLinear previously lacked `amp_end`, making it function as a step instead of a ramp. This update aligns it with Neurodamus by adding support for ramping