### PR TITLE
Add support for compartment reports including soma and named section groups

### DIFF
--- a/bluecellulab/circuit/config/sonata_simulation_config.py
+++ b/bluecellulab/circuit/config/sonata_simulation_config.py
@@ -109,6 +109,12 @@ class SonataSimulationConfig:
     def connection_entries(self) -> list[ConnectionOverrides]:
         return self._connection_entries() + self._connection_overrides
 
+    def report_file_path(self, report_cfg: dict, report_key: str) -> Path:
+        """Resolve the full path for the report output file."""
+        output_dir = Path(self.output_root_path)
+        file_name = report_cfg.get("file_name", f"{report_key}.h5")
+        return output_dir / file_name
+
     @property
     def base_seed(self) -> int:
         return self.impl.run.random_seed

--- a/bluecellulab/circuit/config/sonata_simulation_config.py
+++ b/bluecellulab/circuit/config/sonata_simulation_config.py
@@ -88,7 +88,6 @@ class SonataSimulationConfig:
 
     @lru_cache(maxsize=1)
     def get_node_sets(self) -> dict[str, dict]:
-        print(self.impl.circuit.config.get("node_sets_file"))
         filepath = self.impl.circuit.config.get("node_sets_file")
         if not filepath:
             raise ValueError("No 'node_sets_file' entry found in SONATA config.")

--- a/bluecellulab/circuit/iotools.py
+++ b/bluecellulab/circuit/iotools.py
@@ -21,7 +21,7 @@ from typing import List
 import numpy as np
 import h5py
 
-from bluecellulab.tools import get_sections, resolve_segments
+from bluecellulab.tools import resolve_segments
 from bluecellulab.cell.cell_dict import CellDict
 from bluecellulab.circuit.node_id import CellId
 

--- a/bluecellulab/circuit_simulation.py
+++ b/bluecellulab/circuit_simulation.py
@@ -799,7 +799,6 @@ class CircuitSimulation:
                 raise NotImplementedError(f"Report type '{report_type}' is not supported.")
 
             output_path = self.circuit_access.config.report_file_path(report_cfg, report_name)
-            print(f"Writing report '{report_name}' to {output_path}")
             if section == "compartment_set":
                 if report_cfg.get("cells") is not None:
                     raise ValueError(

--- a/bluecellulab/circuit_simulation.py
+++ b/bluecellulab/circuit_simulation.py
@@ -653,7 +653,6 @@ class CircuitSimulation:
             forward_skip_value=forward_skip_value,
             show_progress=show_progress)
 
-        self.write_reports()
 
     def get_mainsim_voltage_trace(
             self, cell_id: int | tuple[str, int], t_start=None, t_stop=None, t_step=None
@@ -790,6 +789,7 @@ class CircuitSimulation:
                                  emodel_properties=cell_kwargs['emodel_properties'])
 
     def write_reports(self):
+        """Write all reports defined in the simulation config."""
         report_entries = self.circuit_access.config.get_report_entries()
 
         for report_name, report_cfg in report_entries.items():
@@ -799,8 +799,8 @@ class CircuitSimulation:
             if report_type != "compartment":
                 raise NotImplementedError(f"Report type '{report_type}' is not supported.")
 
-            output_path = f"./{report_name}.h5"
-
+            output_path = self.circuit_access.config.report_file_path(report_cfg, report_name)
+            print(f"Writing report '{report_name}' to {output_path}")
             if section == "compartment_set":
                 if report_cfg.get("cells") is not None:
                     raise ValueError(

--- a/bluecellulab/circuit_simulation.py
+++ b/bluecellulab/circuit_simulation.py
@@ -653,7 +653,6 @@ class CircuitSimulation:
             forward_skip_value=forward_skip_value,
             show_progress=show_progress)
 
-
     def get_mainsim_voltage_trace(
             self, cell_id: int | tuple[str, int], t_start=None, t_stop=None, t_step=None
     ) -> np.ndarray:

--- a/bluecellulab/simulation/report.py
+++ b/bluecellulab/simulation/report.py
@@ -1,0 +1,76 @@
+# Copyright 2025 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Report class of bluecellulab."""
+
+import logging
+
+from bluecellulab.tools import get_section, resolve_segments
+
+logger = logging.getLogger(__name__)
+
+
+def _configure_recording(cell, report_cfg, source, source_type, report_name):
+    variable = report_cfg.get("variable_name", "v")
+    if variable != "v":
+        logger.warning(f"Unsupported variable '{variable}' for report '{report_name}'")
+        return
+
+    node_id = cell.cell_id
+    compartment_nodes = source.get("compartment_set") if source_type == "compartment_set" else None
+
+    targets = resolve_segments(cell, report_cfg, node_id, compartment_nodes, source_type)
+    for section_name, seg in targets:
+        for sec in get_section(cell, section_name):
+            try:
+                cell.add_voltage_recording(section=sec, segx=seg)
+            except Exception as e:
+                logger.warning(f"Failed to record voltage at {section_name}({seg}) on GID {node_id} for report '{report_name}': {e}")
+
+
+def configure_all_reports(cells, simulation_config):
+    report_entries = simulation_config.get_report_entries()
+
+    for report_name, report_cfg in report_entries.items():
+        report_type = report_cfg.get("type", "compartment")
+        section = report_cfg.get("section", "soma")
+
+        if report_type != "compartment":
+            raise NotImplementedError(f"Report type '{report_type}' is not supported.")
+
+        if section == "compartment_set":
+            source_type = "compartment_set"
+            source_sets = simulation_config.get_compartment_sets()
+            source_name = report_cfg.get("compartments")
+        else:
+            source_type = "node_set"
+            source_sets = simulation_config.get_node_sets()
+            source_name = report_cfg.get("cells")
+
+        source = source_sets.get(source_name)
+        if not source:
+            logger.warning(f"{source_type.title()} '{source_name}' not found for report '{report_name}'")
+            continue
+
+        population = source["population"]
+        node_ids = (
+            [entry[0] for entry in source["compartment_set"]]
+            if source_type == "compartment_set"
+            else source["node_id"]
+        )
+
+        for node_id in node_ids:
+            cell = cells.get((population, node_id))
+            if not cell:
+                continue
+            _configure_recording(cell, report_cfg, source, source_type, report_name)

--- a/bluecellulab/simulation/report.py
+++ b/bluecellulab/simulation/report.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from bluecellulab.tools import get_sections, resolve_segments
+from bluecellulab.tools import resolve_segments
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ def _configure_recording(cell, report_cfg, source, source_type, report_name):
             logger.warning(
                 f"Failed to record voltage at {sec_name}({seg}) on GID {node_id} for report '{report_name}': {e}"
             )
+
 
 def configure_all_reports(cells, simulation_config):
     report_entries = simulation_config.get_report_entries()

--- a/bluecellulab/tools.py
+++ b/bluecellulab/tools.py
@@ -505,9 +505,10 @@ def validate_section_and_segment(cell: Cell, section_name: str, segment_position
     if not (0.0 <= segment_position <= 1.0):
         raise ValueError(f"Segment position must be between 0.0 and 1.0, got {segment_position}.")
 
+
 def get_section(cell, section_name: str):
-    """
-    Return a single, fully specified NEURON section (e.g., 'soma[0]', 'dend[3]').
+    """Return a single, fully specified NEURON section (e.g., 'soma[0]',
+    'dend[3]').
 
     Raises:
         ValueError or TypeError if the section is not found or invalid.
@@ -521,9 +522,9 @@ def get_section(cell, section_name: str):
     available = ", ".join(cell.sections.keys())
     raise ValueError(f"Section '{section_name}' not found. Available: [{available}]")
 
+
 def get_sections(cell, section_name: str):
-    """
-    Return a list of NEURON sections.
+    """Return a list of NEURON sections.
 
     If the section name is a fully specified one (e.g., 'dend[3]'), return it as a list of one.
     If the section name is a base name (e.g., 'dend'), return all matching sections like 'dend[0]', 'dend[1]', etc.

--- a/tests/test_circuit/test_iotools.py
+++ b/tests/test_circuit/test_iotools.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Blue Brain Project / EPFL
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SONATA input/output operations."""
+
+import pytest
+import numpy as np
+import h5py
+from pathlib import Path
+
+from bluecellulab.circuit.iotools import (
+    write_sonata_report_file
+)
+from bluecellulab.cell import Cell
+from bluecellulab.circuit.circuit_access import EmodelProperties
+
+
+@pytest.fixture
+def mock_cell():
+    """Create a mock cell for testing."""
+    emodel_properties = EmodelProperties(
+        threshold_current=1.1433533430099487,
+        holding_current=1.4146618843078613,
+        AIS_scaler=1.4561502933502197,
+        soma_scaler=1.0
+    )
+    cell = Cell(
+        f"{Path(__file__).parent.parent}/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc",
+        f"{Path(__file__).parent.parent}/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc",
+        template_format="v6",
+        emodel_properties=emodel_properties
+    )
+    return cell
+
+
+def test_write_sonata_report_file(tmp_path):
+    """Test writing SONATA report file directly."""
+    data_matrix = [np.sin(np.linspace(0, 2 * np.pi, 100)) for _ in range(3)]
+    node_ids = [1, 1, 1]
+    index_pointers = [0, 1, 2, 3]
+    element_ids = [0, 1, 2]
+    report_cfg = {
+        "start_time": 0.0,
+        "end_time": 10.0,
+        "dt": 0.1
+    }
+
+    output_file = tmp_path / "test_direct_report.h5"
+    write_sonata_report_file(
+        str(output_file),
+        "TestPop",
+        data_matrix,
+        node_ids,
+        index_pointers,
+        element_ids,
+        report_cfg
+    )
+
+    with h5py.File(output_file, 'r') as f:
+        assert "report/TestPop" in f
+        report = f["report/TestPop"]
+
+        # Check data dimensions and type
+        data = report["data"]
+        assert data.shape == (100, 3)
+        assert data.dtype == np.float32
+        assert data.attrs["units"] == "mV"
+
+        # Verify mapping data
+        mapping = report["mapping"]
+        assert np.array_equal(mapping["node_ids"][:], [1, 1, 1])
+        assert np.array_equal(mapping["index_pointers"][:], [0, 1, 2, 3])
+        assert np.array_equal(mapping["element_ids"][:], [0, 1, 2])
+        assert np.array_equal(mapping["time"][:], [0.0, 10.0, 0.1])
+        assert mapping["time"].attrs["units"] == "ms"

--- a/tests/test_circuit/test_reports.py
+++ b/tests/test_circuit/test_reports.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Blue Brain Project / EPFL
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for simulation compartment reports."""
+
+
+from pathlib import Path
+import pytest
+
+from bluecellulab import CircuitSimulation
+from bluecellulab.simulation.report import configure_all_reports, _configure_recording
+from bluecellulab.cell import Cell
+from bluecellulab.cell.cell_dict import CellDict
+from bluecellulab.circuit.circuit_access import EmodelProperties
+
+
+@pytest.fixture
+def mock_cell():
+    """Create a mock cell for testing."""
+    emodel_properties = EmodelProperties(
+        threshold_current=1.1433533430099487,
+        holding_current=1.4146618843078613,
+        AIS_scaler=1.4561502933502197,
+        soma_scaler=1.0
+    )
+    cell = Cell(
+        f"{Path(__file__).parent.parent}/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc",
+        f"{Path(__file__).parent.parent}/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc",
+        template_format="v6",
+        emodel_properties=emodel_properties
+    )
+    cell.cell_id = ("TestPop", 1)
+    return cell
+
+
+def test_compartment_report_uses_output_dir(mock_cell, tmp_path):
+    """Test that report file is written under config['output']['output_dir'] using the report key as filename."""
+    from pathlib import Path
+    import h5py
+
+    simulation_config = f"{Path(__file__).parent.parent}/examples/sim_quick_scx_sonata_multicircuit/simulation_config_hypamp.json"
+    sim = CircuitSimulation(simulation_config)
+
+    cell_ids = [("NodeA", 0)]
+    sim.cells = CellDict()
+    sim.cells[("NodeA", 0)] = mock_cell
+    mock_cell.add_voltage_recording(mock_cell.soma, 0.5)
+
+    # Inject report config manually
+    report_cfg = {
+        "type": "compartment",
+        "cells": "test_nodes",
+        "sections": "soma",
+        "compartments": "center",
+        "variable_name": "v",
+        "dt": 0.1,
+        "start_time": 0.0,
+        "end_time": 10.0
+    }
+
+    sim.circuit_access.config.get_report_entries = lambda: {
+        "soma": report_cfg
+    }
+    sim.circuit_access.config.get_node_sets = lambda: {
+        "test_nodes": {"population": "NodeA", "node_id": [0]}
+    }
+
+    # Override report_file_path to resolve inside tmp_path
+    sim.circuit_access.config.report_file_path = lambda report_cfg, report_key: tmp_path / f"{report_key}.h5"
+    # Run simulation
+    sim.instantiate_gids(cell_ids, add_stimuli=True, add_synapses=False)
+    sim.run(t_stop=10.0)
+    sim.write_reports()
+
+    # Check expected file
+    output_file = tmp_path / "soma.h5"
+    assert output_file.exists()
+
+    with h5py.File(output_file, "r") as f:
+        assert "report/NodeA" in f
+        report = f["report/NodeA"]
+        assert "data" in report
+        assert "mapping" in report
+
+        data = report["data"][:]
+        assert data.shape[1] == 1  # one compartment
+        assert data.shape[0] > 0   # some time steps
+
+        mapping = report["mapping"]
+        assert "node_ids" in mapping
+        assert "index_pointers" in mapping
+        assert "element_ids" in mapping
+        assert "time" in mapping
+
+
+def test_invalid_report_type():
+    """Test error handling for invalid report types."""
+    sim = CircuitSimulation(f"{Path(__file__).parent.parent}/examples/sim_quick_scx_sonata_multicircuit/simulation_config_hypamp.json")
+
+    # Mock invalid report config
+    report_cfg = {
+        "type": "invalid_type",
+        "cells": "all_cells",
+        "section": "soma"
+    }
+
+    with pytest.raises(NotImplementedError, match=r"Report type 'invalid_type' is not supported"):
+        configure_all_reports(sim.cells, type("MockConfig", (), {"get_report_entries": lambda: {"test": report_cfg}}))
+
+
+def test_invalid_compartments_value(mock_cell):
+    """Test error handling for invalid compartments value in node-based recording."""
+    from types import SimpleNamespace
+    from pathlib import Path
+    import pytest
+
+    # Instantiate a dummy CircuitSimulation without calling __init__
+    sim = CircuitSimulation.__new__(CircuitSimulation)
+
+    # Set up cell dictionary with one mock cell
+    sim.cells = CellDict()
+    sim.cells[("TestPop", 1)] = mock_cell
+
+    # Mock circuit access and config
+    sim.circuit_access = SimpleNamespace()
+    sim.circuit_access.config = SimpleNamespace()
+
+    # Mock the report entries to include an invalid 'compartments' value
+    sim.circuit_access.config.get_report_entries = lambda: {
+        "invalid_report": {
+            "type": "compartment",
+            "cells": "all_cells",
+            "section": "soma[0]",
+            "compartments": "invalid",  # This should trigger the ValueError
+            "variable_name": "v"
+        }
+    }
+
+    # Provide a dummy node set that would pass if 'compartments' were valid
+    sim.circuit_access.config.get_node_sets = lambda: {
+        "all_cells": {"population": "TestPop", "node_id": [1]}
+    }
+
+    # Inject a dummy report_file_path method to satisfy the call in write_reports
+    sim.circuit_access.config.report_file_path = lambda report_cfg, report_key: Path(f"{report_key}.h5")
+
+    # Expect ValueError due to invalid compartments value
+    with pytest.raises(ValueError, match=r"Unsupported 'compartments' value 'invalid'"):
+        sim.write_reports()
+
+
+def test_unsupported_variable(mock_cell):
+    """Test handling of unsupported recording variables."""
+    sim = CircuitSimulation(f"{Path(__file__).parent.parent}/examples/sim_quick_scx_sonata_multicircuit/simulation_config_hypamp.json")
+
+    # Configure recording with unsupported variable
+    report_cfg = {
+        "type": "compartment",
+        "cells": "all_cells",
+        "section": "soma[0]",
+        "compartments": "center",
+        "variable_name": "unsupported"
+    }
+
+    # Should log warning but not raise error
+    _configure_recording(mock_cell, report_cfg, {"population": "TestPop", "node_id": [1]}, "node_set", "test_report")

--- a/tests/test_circuit/test_section_tools.py
+++ b/tests/test_circuit/test_section_tools.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Blue Brain Project / EPFL
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for section resolution tools."""
+
+import pytest
+from pathlib import Path
+from bluecellulab.cell import Cell
+from bluecellulab.circuit.circuit_access import EmodelProperties
+from bluecellulab.tools import get_section, get_sections, resolve_segments
+
+
+@pytest.fixture
+def mock_cell():
+    """Create a mock cell for testing."""
+    emodel_properties = EmodelProperties(
+        threshold_current=1.1433533430099487,
+        holding_current=1.4146618843078613,
+        AIS_scaler=1.4561502933502197,
+        soma_scaler=1.0
+    )
+    return Cell(
+        f"{Path(__file__).parent.parent}/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc",
+        f"{Path(__file__).parent.parent}/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc",
+        template_format="v6",
+        emodel_properties=emodel_properties
+    )
+
+
+def test_get_section_direct_match(mock_cell):
+    """Test get_section with a direct section name match."""
+    section = get_section(mock_cell, "soma[0]")
+    assert hasattr(section, "nseg")
+
+
+def test_get_section_soma_fallback(mock_cell):
+    """Test get_section fallback from 'soma' to 'soma[0]'."""
+    section = get_sections(mock_cell, "soma")
+    assert hasattr(section[0], "nseg")
+
+
+def test_get_section_invalid_name(mock_cell):
+    """Test get_section with an invalid section name (not in cell.sections)."""
+    with pytest.raises(ValueError, match=r"Section 'invalid' not found\. Available:"):
+        get_sections(mock_cell, "invalid")
+
+
+def test_resolve_segments_node_set(mock_cell):
+    """Test resolve_segments for node_set recording."""
+    report_cfg = {
+        "section": "soma",
+        "compartments": "center"
+    }
+    targets = resolve_segments(mock_cell, report_cfg, 1, None, "node_set")
+    _, sec_name, seg = targets[0]
+    assert sec_name == "soma[0]"
+    assert seg == 0.5
+
+
+def test_resolve_segments_node_set_all(mock_cell):
+    """Test resolve_segments for node_set recording with all compartments."""
+    report_cfg = {
+        "section": "dend[0]",
+        "compartments": "all"
+    }
+    targets = resolve_segments(mock_cell, report_cfg, 1, None, "node_set")
+    assert len(targets) == 1
+
+
+def test_resolve_segments_compartment_set(mock_cell):
+    """Test resolve_segments for compartment_set recording."""
+    compartment_nodes = [[1, "soma", 0.5], [1, "dend[0]", 0.25]]
+    targets = resolve_segments(mock_cell, {}, 1, compartment_nodes, "compartment_set")
+    assert len(targets) == 2
+    _, sec_name, seg = targets[0]
+    assert sec_name == "soma"
+    assert seg == 0.5
+    _, sec_name, seg = targets[1]
+    assert sec_name == "dend[0]"
+    assert seg == 0.25


### PR DESCRIPTION
Introduces functionality for writing SONATA-compatible compartment reports from NEURON simulations in `bluecellulab`.

#### Supported Features

- **Soma reports**: `"section": "soma"` is resolved to `soma[0]`, supporting `"center"` (0.5) and `"all"` segments.
- **Grouped sections**: `"section": "dend"` or similar resolves to all matching sections like `dend[0]`, `dend[1]`, etc.
- **Output path handling**: Uses `config['output']['output_dir']` to construct `<output_dir>/<report_name>.h5`.

#### Additions

- `write_compartment_report()`: Writes voltage data in SONATA HDF5 format.
- `resolve_segments()`: Determines target segments from section/compartment config.
- `get_section()` / `get_sections()`:
  - `get_section()`: Resolves fully specified names like `"soma[0]"`.
  - `get_sections()`: Resolves base names like `"dend"` to all matching sections.
- `"variable_name": "v"` support; other variables are logged and skipped.
- Test coverage includes:
  - Section resolution
  - Node-based compartment targeting
  - Output file structure
  - Error handling for invalid configs

#### Limitations

- `"sections": "compartment_set"` is parsed but **not fully supported in LibSONATA output**.
- Explicit section names like `"dend[4]"` in the config are not supported—only group names like `"dend"` are accepted—because LibSONATA currently does not support addressing individual sections directly in reports.
- Only voltage (`"v"`) is currently recorded.

#### Notes

- If `output_dir` is provided in the config, reports are written there, otherwise, defaults to `./<report_name>.h5`.
- Files are overwritten if they already exist, consistent with existing plot behavior.