### PR TITLE
Combine and update the node_sets in node_set_file of simulation_config.json with those in node_set_file of circuit config.json + update some sonata stimuli optional arguments

### DIFF
--- a/bluecellulab/circuit/config/sonata_simulation_config.py
+++ b/bluecellulab/circuit/config/sonata_simulation_config.py
@@ -86,6 +86,7 @@ class SonataSimulationConfig:
         with open(filepath, 'r') as f:
             return json.load(f)
 
+    @lru_cache(maxsize=1)
     def get_node_sets(self) -> dict[str, dict]:
         circuit_filepath = self.impl.circuit.config.get("node_sets_file")
         base_node_sets = {}

--- a/bluecellulab/circuit/config/sonata_simulation_config.py
+++ b/bluecellulab/circuit/config/sonata_simulation_config.py
@@ -88,7 +88,7 @@ class SonataSimulationConfig:
 
     @lru_cache(maxsize=1)
     def get_node_sets(self) -> dict[str, dict]:
-        filepath = self.impl.circuit.config.get("node_sets_file")
+        filepath = self.impl.config.get("node_sets_file")
         if not filepath:
             raise ValueError("No 'node_sets_file' entry found in SONATA config.")
         with open(filepath, 'r') as f:

--- a/bluecellulab/circuit/config/sonata_simulation_config.py
+++ b/bluecellulab/circuit/config/sonata_simulation_config.py
@@ -99,10 +99,10 @@ class SonataSimulationConfig:
                 sim_node_sets = json.load(f)
         # Overwrite/add entries
         base_node_sets.update(sim_node_sets)
- 
+
         if not base_node_sets:
             raise ValueError("No 'node_sets_file' found in simulation or circuit config.")
- 
+
         return base_node_sets
 
     @lru_cache(maxsize=1)

--- a/bluecellulab/circuit/config/sonata_simulation_config.py
+++ b/bluecellulab/circuit/config/sonata_simulation_config.py
@@ -86,13 +86,24 @@ class SonataSimulationConfig:
         with open(filepath, 'r') as f:
             return json.load(f)
 
-    @lru_cache(maxsize=1)
     def get_node_sets(self) -> dict[str, dict]:
-        filepath = self.impl.config.get("node_sets_file")
-        if not filepath:
-            raise ValueError("No 'node_sets_file' entry found in SONATA config.")
-        with open(filepath, 'r') as f:
-            return json.load(f)
+        circuit_filepath = self.impl.circuit.config.get("node_sets_file")
+        base_node_sets = {}
+        if circuit_filepath:
+            with open(circuit_filepath, "r") as f:
+                base_node_sets = json.load(f)
+
+        sim_filepath = self.impl.config.get("node_sets_file")
+        if sim_filepath:
+            with open(sim_filepath, "r") as f:
+                sim_node_sets = json.load(f)
+        # Overwrite/add entries
+        base_node_sets.update(sim_node_sets)
+ 
+        if not base_node_sets:
+            raise ValueError("No 'node_sets_file' found in simulation or circuit config.")
+ 
+        return base_node_sets
 
     @lru_cache(maxsize=1)
     def get_report_entries(self) -> dict[str, dict]:

--- a/bluecellulab/circuit/config/sonata_simulation_config.py
+++ b/bluecellulab/circuit/config/sonata_simulation_config.py
@@ -97,8 +97,8 @@ class SonataSimulationConfig:
         if sim_filepath:
             with open(sim_filepath, "r") as f:
                 sim_node_sets = json.load(f)
-        # Overwrite/add entries
-        base_node_sets.update(sim_node_sets)
+            # Overwrite/add entries
+            base_node_sets.update(sim_node_sets)
 
         if not base_node_sets:
             raise ValueError("No 'node_sets_file' found in simulation or circuit config.")

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -251,7 +251,7 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 percent_start=stimulus_entry["percent_start"],
-                percent_end=stimulus_entry["percent_end"],
+                percent_end=stimulus_entry.get("percent_end", stimulus_entry["percent_start"]),
             )
         elif pattern == Pattern.SYNAPSE_REPLAY:
             return SynapseReplay(

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -243,7 +243,7 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 amp_start=stimulus_entry["amp_start"],
-                amp_end=stimulus_entry.get("amp_end", stimulus_entry["amp_end"]),
+                amp_end=stimulus_entry.get("amp_end", stimulus_entry["amp_start"]),
             )
         elif pattern == Pattern.RELATIVE_LINEAR:
             return RelativeLinear(
@@ -251,7 +251,7 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 percent_start=stimulus_entry["percent_start"],
-                percent_end=stimulus_entry.get("percent_end", stimulus_entry["percent_end"]),
+                percent_end=stimulus_entry.get("percent_end", stimulus_entry["percent_start"]),
             )
         elif pattern == Pattern.SYNAPSE_REPLAY:
             return SynapseReplay(

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -243,7 +243,7 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 amp_start=stimulus_entry["amp_start"],
-                amp_end=stimulus_entry["amp_end"],
+                amp_end=stimulus_entry.get("amp_end", stimulus_entry["amp_start"]),
             )
         elif pattern == Pattern.RELATIVE_LINEAR:
             return RelativeLinear(
@@ -285,7 +285,7 @@ class Stimulus:
                 decay_time=stimulus_entry["decay_time"],
                 mean_percent=stimulus_entry["mean_percent"],
                 sd_percent=stimulus_entry["sd_percent"],
-                relative_skew=stimulus_entry.get("RelativeSkew", 0.5),
+                relative_skew=stimulus_entry.get("relative_skew", 0.5),
                 seed=stimulus_entry.get("random_seed", None),
                 mode=ClampMode(stimulus_entry.get("input_type", "current_clamp").lower()),
                 reversal=stimulus_entry.get("reversal", 0.0)

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -243,7 +243,7 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 amp_start=stimulus_entry["amp_start"],
-                amp_end=stimulus_entry.get("amp_end", stimulus_entry["amp_start"]),
+                amp_end=stimulus_entry.get("amp_end", stimulus_entry["amp_end"]),
             )
         elif pattern == Pattern.RELATIVE_LINEAR:
             return RelativeLinear(
@@ -251,7 +251,7 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 percent_start=stimulus_entry["percent_start"],
-                percent_end=stimulus_entry.get("percent_end", stimulus_entry["percent_start"]),
+                percent_end=stimulus_entry.get("percent_end", stimulus_entry["percent_end"]),
             )
         elif pattern == Pattern.SYNAPSE_REPLAY:
             return SynapseReplay(

--- a/tests/test_circuit/test_simulation_config.py
+++ b/tests/test_circuit/test_simulation_config.py
@@ -254,7 +254,7 @@ def test_get_node_sets(tmp_path):
         }
     }))
     sim = SonataSimulationConfig.__new__(SonataSimulationConfig)
-    sim.impl = type("impl", (), {"circuit": type("circuit", (), {"config": {"node_sets_file": str(file)}})})
+    sim.impl = type("impl", (), {"config": {"node_sets_file": str(file)}})
     result = sim.get_node_sets()
     assert "target_cells" in result
     assert result["target_cells"]["node_id"] == [0, 1, 2]


### PR DESCRIPTION
- Combine and update the node_sets in node_set_file of simulation_config.json with those in node_set_file of circuit config.json
- This was needed for small microcircuit simulations (don't merge `fix-spike-replay` branch yet.
- According to [SONATA](https://sonata-extension.readthedocs.io/en/latest/sonata_simulation.html#node-sets-file) documentation `simulation_config.json` 's node_set_file entry [updates](https://sonata-extension.readthedocs.io/en/latest/sonata_simulation.html#node-sets-file) the base node sets from circuit_config.json  node_sets_file entry:
> The circuit_config nodesets are considered the base set of nodesets; the values in this file are added to the possible 
> nodesets, and overwrite any duplicates from the base set.
- The small microcircuit simulation use custom node_sets in new node_sets.json file created via obi-one.
- The new node_set is only present `node_sets_file` in simulation_config.json along with all the node_sets of `node_sets_file` of circuit_config.json`. So, I think on the  node_set_file from simulation_config.json is used.
- Also, updating the optional entries `percent_end` for [relative linear](https://sonata-extension.readthedocs.io/en/latest/sonata_simulation.html#relative-linear-current-clamp) and other stimuli in the docs.