### PR TITLE
Adding efel Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "networkx>=3.1",
     "h5py>=3.8.0",
     "seaborn",
-    "efel>5.7.19",
+    "efel>=5.7.19",
 ]
 requires-python = ">=3.9"
 


### PR DESCRIPTION
- `validation.py` and `analysis.py` use efel but we don't have it as a dependency. 