### PR TITLE
Add Python 3.14 support 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Utilities",
 ]
 keywords = [
@@ -29,7 +30,7 @@ keywords = [
 ]
 dependencies = [
     "NEURON>=8.0.2",
-    "numpy>=2.0.0,<2.4",
+    "numpy>=2.0.0,<2.5",
     "matplotlib>=3.0.0,<4.0.0",
     "pandas>=1.0.0,<3.0.0",
     "bluepysnap>=3.0.0,<4.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ envdir =
     py3: {toxworkdir}/py3
 package = wheel
 deps =
-    pytest>=7.3.1,<8.0.0
-    coverage>=7.5,<7.6
+    pytest>=7.3.1
+    coverage>=7.5
     pytest-cov>=4.1.0
     pytest-timeout>=2.1.0
     pytest-xdist>=3.3.1  # multiprocessing


### PR DESCRIPTION
- Add Python 3.14 to pyproject.toml 
- Bump numpy upper bound from <2.4 to <2.5 for 3.14 wheel availability 
- Add Python 3.14 to CI in GitHub Actions 
- Remove upper bounds on pytest and coverage in tox.ini to allow versions that support Python 3.14 (pytest 8.x, coverage 7.6+) 
- No source code changes needed: the codebase is already compatible with Python 3.14 (no removed APIs used, PEP 649 deferred annotations compatible with existing 'from __future__ import annotations' usage).