### PR TITLE
Fix MPI pre-cell handling, node set resolution, and post_gid fallback

### DIFF
--- a/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
+++ b/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
@@ -277,13 +277,6 @@ class SonataCircuitAccess(CircuitAccess):
             ids = self._circuit.nodes.ids(node_set_def)
             return {CellId(x.population, x.id) for x in ids}
 
-    @lru_cache(maxsize=16)
-    def get_target_cell_ids(self, target: str) -> set[CellId]:
-        """Resolve a node set name into a set of CellIds.
-        """
-        node_sets = self.config.get_node_sets()
-        return self._resolve_node_set_to_cell_ids(target, node_sets)
-
     def _resolve_node_set_to_cell_ids(
         self,
         target: str,

--- a/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
+++ b/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
@@ -277,6 +277,45 @@ class SonataCircuitAccess(CircuitAccess):
             ids = self._circuit.nodes.ids(node_set_def)
             return {CellId(x.population, x.id) for x in ids}
 
+    @lru_cache(maxsize=16)
+    def get_target_cell_ids(self, target: str) -> set[CellId]:
+        """Resolve a node set name into a set of CellIds.
+        """
+        node_sets = self.config.get_node_sets()
+        return self._resolve_node_set_to_cell_ids(target, node_sets)
+
+    def _resolve_node_set_to_cell_ids(
+        self,
+        target: str,
+        node_sets: dict[str, object],
+    ) -> set[CellId]:
+        if target not in node_sets:
+            raise KeyError(f"Unknown node set: {target}")
+
+        node_set_def = node_sets[target]
+
+        # Alias/composite node set, e.g. "All": ["L4_SBC", "L5_TPC:B", ...]
+        if isinstance(node_set_def, list):
+            result: set[CellId] = set()
+            for item in node_set_def:
+                if isinstance(item, str) and item in node_sets:
+                    result.update(self._resolve_node_set_to_cell_ids(item, node_sets))
+                else:
+                    raise ValueError(
+                        f"Unsupported composite node set entry {item!r} in node set {target!r}"
+                    )
+            return result
+
+        # Concrete single-population node set
+        if isinstance(node_set_def, dict) and "population" in node_set_def:
+            population = str(node_set_def["population"])
+            ids = self._circuit.nodes[population].ids(node_set_def)
+            return {CellId(population, int(x)) for x in ids}
+
+        # Fallback: let BluePySnap resolve it
+        ids = self._circuit.nodes.ids(node_set_def)
+        return {CellId(x.population, x.id) for x in ids}
+
     @lru_cache(maxsize=100)
     def fetch_cell_info(self, cell_id: CellId) -> pd.Series:
         return self._circuit.nodes[cell_id.population_name].get(cell_id.id)

--- a/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
+++ b/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
@@ -18,7 +18,7 @@ import hashlib
 from functools import lru_cache
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 from bluepysnap.bbp import Cell as SnapCell
 from bluepysnap.circuit_ids import CircuitNodeId, CircuitEdgeIds
@@ -258,15 +258,14 @@ class SonataCircuitAccess(CircuitAccess):
 
     @lru_cache(maxsize=16)
     def get_target_cell_ids(self, target: str) -> set[CellId]:
-        """Resolve a node set name into a set of CellIds.
-        """
+        """Resolve a node set name into a set of CellIds."""
         node_sets = self.config.get_node_sets()
         return self._resolve_node_set_to_cell_ids(target, node_sets)
 
     def _resolve_node_set_to_cell_ids(
         self,
         target: str,
-        node_sets: dict[str, object],
+        node_sets: Mapping[str, object],
     ) -> set[CellId]:
         if target not in node_sets:
             raise KeyError(f"Unknown node set: {target}")

--- a/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
+++ b/bluecellulab/circuit/circuit_access/sonata_circuit_access.py
@@ -258,24 +258,10 @@ class SonataCircuitAccess(CircuitAccess):
 
     @lru_cache(maxsize=16)
     def get_target_cell_ids(self, target: str) -> set[CellId]:
-        # Use merged node_sets from simulation config (includes both circuit and simulation node_sets)
+        """Resolve a node set name into a set of CellIds.
+        """
         node_sets = self.config.get_node_sets()
-        node_set_def = node_sets[target]
-
-        # If node_set specifies a population, query only that population to avoid
-        # "Invalid range: 0-0" errors when other populations are empty
-        if isinstance(node_set_def, dict) and "population" in node_set_def:
-            population = node_set_def["population"]
-            # Single-population query: ids() returns plain integer node IDs,
-            # so the population name is taken from the node_set definition.
-            ids = self._circuit.nodes[population].ids(node_set_def)
-            return {CellId(population, x) for x in ids}
-        else:
-            # Multi-population query: circuit.nodes.ids() returns
-            # CircuitNodeId objects that carry both population and id,
-            # so we extract both fields from each result.
-            ids = self._circuit.nodes.ids(node_set_def)
-            return {CellId(x.population, x.id) for x in ids}
+        return self._resolve_node_set_to_cell_ids(target, node_sets)
 
     def _resolve_node_set_to_cell_ids(
         self,

--- a/bluecellulab/circuit_simulation.py
+++ b/bluecellulab/circuit_simulation.py
@@ -156,7 +156,9 @@ class CircuitSimulation:
         condition_parameters = self.circuit_access.config.condition_parameters()
         set_global_condition_parameters(condition_parameters)
 
-        self.gid_resolver: Optional[GidNamespace] = None
+        self.gids: Optional[GidNamespace] = None
+        self._instantiated_cells_mpi: set[CellId] | None = None
+
 
     def instantiate_gids(
         self,
@@ -335,6 +337,7 @@ class CircuitSimulation:
                     "add_replay option can not be used if add_synapses is False"
                 )
             if self.pc is not None:
+                self._init_instantiated_cells_mpi()
                 self._register_gids_for_mpi()
                 self.pc.barrier()
                 self.pc.setup_transfer()
@@ -737,9 +740,13 @@ class CircuitSimulation:
                     continue
 
                 if self.pc is None:
-                    real_synapse_connection = bool(interconnect_cells) and (pre_local_id in self.cells)
+                    real_synapse_connection = bool(interconnect_cells) and (
+                        pre_local_id in self.cells
+                    )
                 else:
-                    real_synapse_connection = bool(interconnect_cells)
+                    real_synapse_connection = bool(interconnect_cells) and (
+                        pre_local_id in self._instantiated_cells_mpi
+                    )
 
                 if real_synapse_connection:
                     if (
@@ -1234,3 +1241,19 @@ class CircuitSimulation:
             prev = p
 
         return pop_offset
+
+    def _init_instantiated_cells_mpi(self) -> None:
+        """Build the global set of instantiated CellIds across all MPI ranks."""
+        assert self.pc is not None
+
+        local_cells = list(self.cells.keys())
+        gathered = self.pc.py_gather(local_cells, 0)
+
+        if int(self.pc.id()) == 0:
+            all_cells = set()
+            for cell_list in gathered:
+                all_cells.update(cell_list)
+        else:
+            all_cells = None
+
+        self._instantiated_cells_mpi = self.pc.py_broadcast(all_cells, 0)

--- a/bluecellulab/circuit_simulation.py
+++ b/bluecellulab/circuit_simulation.py
@@ -159,7 +159,6 @@ class CircuitSimulation:
         self.gids: Optional[GidNamespace] = None
         self._instantiated_cells_mpi: set[CellId] | None = None
 
-
     def instantiate_gids(
         self,
         cells: int | tuple[str, int] | list[int | tuple[str, int]],
@@ -745,7 +744,8 @@ class CircuitSimulation:
                     )
                 else:
                     real_synapse_connection = bool(interconnect_cells) and (
-                        pre_local_id in self._instantiated_cells_mpi
+                        self._instantiated_cells_mpi is not None
+                        and pre_local_id in self._instantiated_cells_mpi
                     )
 
                 if real_synapse_connection:
@@ -1243,7 +1243,8 @@ class CircuitSimulation:
         return pop_offset
 
     def _init_instantiated_cells_mpi(self) -> None:
-        """Build the global set of instantiated CellIds across all MPI ranks."""
+        """Build the global set of instantiated CellIds across all MPI
+        ranks."""
         assert self.pc is not None
 
         local_cells = list(self.cells.keys())

--- a/bluecellulab/synapse/synapse_types.py
+++ b/bluecellulab/synapse/synapse_types.py
@@ -52,12 +52,12 @@ class Synapse:
             syn_id: tuple[str, int],
             syn_description: pd.Series,
             popids: tuple[int, int],
-            post_gid: int,
+            post_gid: int | None,
             extracellular_calcium: float | None = None):
         """Constructor.
 
         Args:
-            gid: The post-synaptic cell gid.
+            cell_id: Identifier of the postsynaptic cell.
             hoc_args: The synapse location and section in hoc.
             syn_id: A tuple containing a synapse identifier, where the string is
                 the projection name and int is the synapse id. An empty string
@@ -65,8 +65,11 @@ class Synapse:
             syn_description: Parameters of the synapse.
             popids: A tuple containing source and target popids used by the random
                 number generation.
-            extracellular_calcium: The extracellular calcium concentration. Optional
-                and defaults to None.
+            post_gid: Global postsynaptic gid used for RNG seeding and synapse
+                initialization. If None, falls back to cell_id.id for backward
+                compatibility with standalone Cell usage.
+            extracellular_calcium: The extracellular calcium concentration.
+                Optional and defaults to None.
         """
         self.persistent: list[HocObjectType] = []
         self.synapseconfigure_cmds: list[str] = []
@@ -82,7 +85,7 @@ class Synapse:
         self.source_popid, self.target_popid = popids
 
         self.pre_gid = int(self.syn_description[SynapseProperty.PRE_GID])
-        self.post_gid = int(post_gid)
+        self.post_gid = int(cell_id.id if post_gid is None else post_gid)
 
         self.hoc_args = hoc_args
         self.mech_name: str = "not-yet-defined"

--- a/tests/test_circuit/test_circuit_access.py
+++ b/tests/test_circuit/test_circuit_access.py
@@ -270,6 +270,7 @@ def test_get_target_cell_ids_without_population_filter():
 
     assert result == {CellId("popA", 1), CellId("popB", 5)}
 
+
 def test_get_target_cell_ids_composite_node_set():
     access = object.__new__(SonataCircuitAccess)
     access.config = SimpleNamespace(
@@ -294,6 +295,7 @@ def test_get_target_cell_ids_composite_node_set():
         CellId("popB", 5),
     }
 
+
 def test_get_target_cell_ids_nested_composite_node_set():
     access = object.__new__(SonataCircuitAccess)
     access.config = SimpleNamespace(
@@ -317,6 +319,7 @@ def test_get_target_cell_ids_nested_composite_node_set():
         CellId("popA", 1),
         CellId("popB", 5),
     }
+
 
 def test_morph_filepath_h5v1_container_path():
     access = object.__new__(SonataCircuitAccess)

--- a/tests/test_circuit/test_circuit_access.py
+++ b/tests/test_circuit/test_circuit_access.py
@@ -270,6 +270,53 @@ def test_get_target_cell_ids_without_population_filter():
 
     assert result == {CellId("popA", 1), CellId("popB", 5)}
 
+def test_get_target_cell_ids_composite_node_set():
+    access = object.__new__(SonataCircuitAccess)
+    access.config = SimpleNamespace(
+        get_node_sets=lambda: {
+            "A": {"population": "popA", "node_id": [1, 2]},
+            "B": {"population": "popB", "node_id": [5]},
+            "All": ["A", "B"],
+        }
+    )
+    access._circuit = SimpleNamespace(
+        nodes={
+            "popA": SimpleNamespace(ids=lambda _: [1, 2]),
+            "popB": SimpleNamespace(ids=lambda _: [5]),
+        }
+    )
+
+    result = SonataCircuitAccess.get_target_cell_ids(access, "All")
+
+    assert result == {
+        CellId("popA", 1),
+        CellId("popA", 2),
+        CellId("popB", 5),
+    }
+
+def test_get_target_cell_ids_nested_composite_node_set():
+    access = object.__new__(SonataCircuitAccess)
+    access.config = SimpleNamespace(
+        get_node_sets=lambda: {
+            "A": {"population": "popA", "node_id": [1]},
+            "B": {"population": "popB", "node_id": [5]},
+            "AB": ["A", "B"],
+            "All": ["AB"],
+        }
+    )
+    access._circuit = SimpleNamespace(
+        nodes={
+            "popA": SimpleNamespace(ids=lambda _: [1]),
+            "popB": SimpleNamespace(ids=lambda _: [5]),
+        }
+    )
+
+    result = SonataCircuitAccess.get_target_cell_ids(access, "All")
+
+    assert result == {
+        CellId("popA", 1),
+        CellId("popB", 5),
+    }
 
 def test_morph_filepath_h5v1_container_path():
     access = object.__new__(SonataCircuitAccess)

--- a/tests/test_circuit_simulation_mpi.py
+++ b/tests/test_circuit_simulation_mpi.py
@@ -295,3 +295,72 @@ def test_init_instantiated_cells_mpi_non_root_receives_broadcast():
     assert pc.gathered == ([local_cell], 0)
     assert pc.broadcasted == (None, 0)
     assert sim._instantiated_cells_mpi == expected
+
+
+def test_add_connections_mpi_non_instantiated_precell_uses_replay(monkeypatch):
+    sim = make_sim(pc=FakePC(rank=1))
+
+    post_id = CellId("PostPop", 5)
+    pre_id = CellId("PrePop", 3)
+
+    syn = DummySynapse(source_pop="PrePop", pre_gid=3)
+    post_cell = DummyCell(synapses={"syn1": syn})
+    sim.cells = {post_id: post_cell}
+    sim._instantiated_cells_mpi = {post_id}
+
+    class FakeSimulationAccess:
+        def get_spikes(self):
+            return {pre_id: [1.0, 2.0, 3.0]}
+
+    sim.simulation_access = FakeSimulationAccess()
+
+    class FakeCircuitAccess:
+        def __init__(self):
+            self.config = type("cfg", (), {"connection_entries": lambda _self: []})()
+
+    sim.circuit_access = FakeCircuitAccess()
+
+    def fail_global_gid(*args, **kwargs):
+        raise AssertionError("global_gid should not be called for replay connections")
+
+    sim.global_gid = fail_global_gid
+
+    created = []
+
+    class FakeConnection:
+        def __init__(
+            self,
+            synapse,
+            pre_spiketrain=None,
+            pre_cell=None,
+            stim_dt=None,
+            parallel_context=None,
+            spike_threshold=None,
+            spike_location=None,
+            pre_gid=None,
+        ):
+            self.synapse = synapse
+            self.pre_spiketrain = pre_spiketrain
+            self.pre_cell = pre_cell
+            self.parallel_context = parallel_context
+            self.pre_gid = pre_gid
+            self.weight = 1.0
+            self.post_netcon_weight = 1.0
+            created.append(self)
+
+        def set_weight_scalar(self, scalar: float):
+            self.post_netcon_weight = self.weight * scalar
+
+        def set_netcon_delay(self, delay: float):
+            return None
+
+    monkeypatch.setattr(circuit_simulation.bluecellulab, "Connection", FakeConnection)
+
+    sim._add_connections(add_replay=True, interconnect_cells=True)
+
+    assert len(created) == 1
+    assert created[0].parallel_context is None
+    assert created[0].pre_gid is None
+    assert created[0].pre_cell is None
+    assert created[0].pre_spiketrain.tolist() == [1.0, 2.0, 3.0]
+    assert post_cell.connections["syn1"] is created[0]

--- a/tests/test_circuit_simulation_mpi.py
+++ b/tests/test_circuit_simulation_mpi.py
@@ -251,3 +251,47 @@ def test_register_gids_for_mpi_uses_gid_namespace():
     expected_gid = sim.global_gid("PopX", 7)
     assert pc.set_gid2node_calls == [(expected_gid, 1)]
     assert pc.cell_calls == [(expected_gid, "netcon")]
+
+
+def test_init_instantiated_cells_mpi_root_collects_union():
+    cell_a = CellId("PopA", 1)
+    cell_b = CellId("PopB", 2)
+    cell_c = CellId("PopA", 3)
+
+    pc = FakePC(
+        rank=0,
+        gather_result=[
+            [cell_a, cell_b],
+            [cell_c],
+        ],
+    )
+    sim = make_sim(pc=pc)
+    sim.cells = {
+        cell_a: DummyCell(),
+        cell_b: DummyCell(),
+    }
+
+    sim._init_instantiated_cells_mpi()
+
+    assert pc.gathered == ([cell_a, cell_b], 0)
+    assert pc.broadcasted == ({cell_a, cell_b, cell_c}, 0)
+    assert sim._instantiated_cells_mpi == {cell_a, cell_b, cell_c}
+
+
+def test_init_instantiated_cells_mpi_non_root_receives_broadcast():
+    local_cell = CellId("PopA", 1)
+    expected = {local_cell, CellId("PopB", 2)}
+
+    pc = FakePC(
+        rank=1,
+        gather_result=None,
+        broadcast_result=expected,
+    )
+    sim = make_sim(pc=pc)
+    sim.cells = {local_cell: DummyCell()}
+
+    sim._init_instantiated_cells_mpi()
+
+    assert pc.gathered == ([local_cell], 0)
+    assert pc.broadcasted == (None, 0)
+    assert sim._instantiated_cells_mpi == expected

--- a/tests/test_synapse/test_synapse_factory.py
+++ b/tests/test_synapse/test_synapse_factory.py
@@ -91,6 +91,61 @@ class TestSynapseFactory:
         res = SynapseFactory.synlocation_to_segx(section, ipt, syn_offset=-1.0)
         assert res == pytest.approx(0.9999999)
 
+    def test_create_synapse_without_post_gid_uses_cell_id_fallback(self):
+        syn_id = ("a", 0)
+        condition_parameters = Conditions.init_empty()
+        popids = (0, 0)
+        extracellular_calcium = 2.0
+        connection_modifiers = {
+            "Weight": 1.15143,
+            "SpontMinis": 0.0,
+            "SynapseConfigure": [
+                "%s.Use = 1 %s.Use_GB = 1 %s.Use_p = 1 %s.gmax0_AMPA = gmax_p_AMPA %s.rho_GB = 1 %s.rho0_GB = 1 %s.gmax_AMPA = %s.gmax_p_AMPA"
+            ],
+        }
+
+        self.cell.post_gid = None
+
+        synapse = SynapseFactory.create_synapse(
+            self.cell,
+            syn_id,
+            self.syn_description,
+            condition_parameters,
+            popids,
+            extracellular_calcium,
+            connection_modifiers,
+        )
+
+        assert isinstance(synapse, GluSynapse)
+        assert synapse.post_gid == self.cell.cell_id.id
+
+    def test_add_replay_synapse_without_post_gid_uses_cell_id_fallback(self):
+        syn_id = ("a", 0)
+        condition_parameters = Conditions.init_empty()
+        popids = (0, 0)
+        extracellular_calcium = 2.0
+        connection_modifiers = {
+            "Weight": 1.15143,
+            "SpontMinis": 0.0,
+            "SynapseConfigure": [
+                "%s.Use = 1 %s.Use_GB = 1 %s.Use_p = 1 %s.gmax0_AMPA = gmax_p_AMPA %s.rho_GB = 1 %s.rho0_GB = 1 %s.gmax_AMPA = %s.gmax_p_AMPA"
+            ],
+        }
+
+        self.cell.post_gid = None
+
+        self.cell.add_replay_synapse(
+            synapse_id=syn_id,
+            syn_description=self.syn_description,
+            connection_modifiers=connection_modifiers,
+            condition_parameters=condition_parameters,
+            popids=popids,
+            extracellular_calcium=extracellular_calcium,
+        )
+
+        synapse = self.cell.synapses[syn_id]
+        assert synapse.post_gid == self.cell.cell_id.id
+
 
 def test_determine_synapse_type():
     # Mocking a pd.Series for syn_description


### PR DESCRIPTION
This PR fixes three issues in circuit instantiation:
- Fixes MPI pre-cell handling for connections when presynaptic populations are not locally instantiated on a rank.
- Fixes composite multi-population node set resolution for alias node sets (e.g. node sets defined as lists of other node sets).
- Restores standalone synapse creation compatibility by allowing post_gid to fall back to cell_id.id when not explicitly provided.