### PR TITLE
Run notebook example tests serially

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,13 +54,11 @@ envdir={toxworkdir}/{envname}
 extras = examples
 deps =
     pytest>=7.3.1,<9.0.0
-    pytest-xdist>=3.3.1  # multiprocessing
-    pytest-forked>=1.6.0  # isolation
     nbmake>=1.5.1
     scipy>=1.11.1
     seaborn>=0.12.2
 commands =
-    pytest --ignore=examples/7-Extra-Simulation/ --numprocesses=auto --forked --nbmake examples # exclude long tests
+    pytest --nbmake examples --ignore=examples/7-Extra-Simulation/ # exclude long tests
 
 [testenv:docs]
 envdir =


### PR DESCRIPTION
## Description

Run notebook example tests serially with `nbmake` by removing `xdist`/`forked` execution.

This keeps the same notebook coverage, excluding `examples/7-Extra-Simulation/`, but makes the examples test environment more stable and deterministic.