### PR TITLE
Add parametric validation framework

### DIFF
--- a/bluecellulab/validation/__init__.py
+++ b/bluecellulab/validation/__init__.py
@@ -18,7 +18,7 @@ from bluecellulab.validation.base import ValidationOutcome, ValidationTest
 from bluecellulab.validation.criterion import Criterion, GreaterThan
 from bluecellulab.validation.measurement import EfelMeasurement, Measurement
 from bluecellulab.validation.parametric_test import ParametricValidation
-from bluecellulab.validation.protocol import Protocol, StepProtocol
+from bluecellulab.validation.protocol import Protocol, SequenceProtocol, StepProtocol
 
 __all__ = [
     "Criterion",
@@ -27,6 +27,7 @@ __all__ = [
     "Measurement",
     "ParametricValidation",
     "Protocol",
+    "SequenceProtocol",
     "StepProtocol",
     "ValidationOutcome",
     "ValidationTest",

--- a/bluecellulab/validation/__init__.py
+++ b/bluecellulab/validation/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation framework for electrophysiology simulations."""
+
+from bluecellulab.validation.base import ValidationOutcome, ValidationTest
+from bluecellulab.validation.criterion import Criterion, GreaterThan
+from bluecellulab.validation.measurement import EfelMeasurement, Measurement
+from bluecellulab.validation.parametric_test import ParametricValidation
+from bluecellulab.validation.protocol import Protocol, StepProtocol
+
+__all__ = [
+    "Criterion",
+    "EfelMeasurement",
+    "GreaterThan",
+    "Measurement",
+    "ParametricValidation",
+    "Protocol",
+    "StepProtocol",
+    "ValidationOutcome",
+    "ValidationTest",
+]

--- a/bluecellulab/validation/base.py
+++ b/bluecellulab/validation/base.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base abstractions for the validation framework."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ValidationOutcome:
+    """Standard result of a validation test.
+
+    Contains everything needed for OBI-One to register a ValidationResult entity.
+
+    Attributes:
+        name: Stable identifier/name for this validation (used for dedup and display).
+        passed: Whether the validation criteria were met.
+        details: Human-readable explanation of the result.
+        figures: Paths to generated figure files (plots, traces, etc.).
+    """
+
+    name: str
+    passed: bool
+    details: str
+    figures: list[Path] = field(default_factory=list)
+
+
+class ValidationTest(ABC):
+    """Abstract base class for all validation tests.
+
+    A validation test encapsulates a complete check: stimulate a cell,
+    measure a property, and determine pass/fail against a criterion.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Stable identifier for this validation test."""
+
+    @abstractmethod
+    def run(self, template_params, rheobase: float, out_dir: Path) -> ValidationOutcome:
+        """Execute the validation test.
+
+        Args:
+            template_params: BlueCelluLab TemplateParams for creating the cell.
+            rheobase: The rheobase (threshold) current in nA.
+            out_dir: Directory to write output figures.
+
+        Returns:
+            A ValidationOutcome with the test result.
+        """

--- a/bluecellulab/validation/criterion.py
+++ b/bluecellulab/validation/criterion.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Criteria for determining pass/fail of a validation measurement."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import numpy as np
+
+
+class Criterion(ABC):
+    """Abstract base for pass/fail criteria applied to a measurement value."""
+
+    @abstractmethod
+    def evaluate(self, value) -> bool:
+        """Evaluate whether the measured value meets this criterion."""
+
+    @abstractmethod
+    def describe(self, value) -> str:
+        """Human-readable description of the evaluation result."""
+
+
+@dataclass
+class GreaterThan(Criterion):
+    """Passes if the measured value is strictly greater than a threshold.
+
+    For array-valued measurements (e.g. AP_amplitude per spike), all values
+    must exceed the threshold.
+
+    Attributes:
+        threshold: The value that must be exceeded.
+    """
+
+    threshold: float
+
+    def evaluate(self, value) -> bool:
+        result = np.all(np.asarray(value) > self.threshold)
+        return bool(result)
+
+    def describe(self, value) -> str:
+        passed = self.evaluate(value)
+        # Summarize array values
+        arr = np.asarray(value)
+        if arr.ndim == 0 or arr.size == 1:
+            display = f"{float(arr):.4g}"
+        else:
+            display = f"min={float(arr.min()):.4g}, mean={float(arr.mean()):.4g}, max={float(arr.max()):.4g}"
+
+        if passed:
+            return f"Value ({display}) is greater than {self.threshold}."
+        return f"Value ({display}) is not greater than {self.threshold}."

--- a/bluecellulab/validation/measurement.py
+++ b/bluecellulab/validation/measurement.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measurements extract quantitative values from simulation recordings."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import efel
+
+from bluecellulab.analysis.inject_sequence import Recording
+
+
+class Measurement(ABC):
+    """Abstract base for extracting a value from a simulation recording."""
+
+    @abstractmethod
+    def extract(self, recording: Recording, stim_start: float, stim_end: float):
+        """Extract a measurement value from a recording.
+
+        Args:
+            recording: The simulation recording containing time, voltage, current.
+            stim_start: Stimulus onset time in ms.
+            stim_end: Stimulus offset time in ms.
+
+        Returns:
+            The measured value (type depends on the specific measurement).
+        """
+
+
+@dataclass
+class EfelMeasurement(Measurement):
+    """Extract an eFEL feature from a recording.
+
+    Attributes:
+        feature_name: The eFEL feature to extract (e.g. "Spikecount", "AP_amplitude").
+    """
+
+    feature_name: str
+
+    def extract(self, recording: Recording, stim_start: float, stim_end: float):
+        """Extract the eFEL feature value from the recording.
+
+        Returns:
+            The scalar feature value, or None if extraction fails.
+        """
+        trace = {
+            "T": recording.time,
+            "V": recording.voltage,
+            "stim_start": [stim_start],
+            "stim_end": [stim_end],
+        }
+        features_results = efel.get_feature_values([trace], [self.feature_name])
+        result = features_results[0][self.feature_name]
+        if result is None or len(result) == 0:
+            return None
+        # For scalar features (e.g. Spikecount), return the single value.
+        if len(result) == 1:
+            return result[0]
+        return result

--- a/bluecellulab/validation/parametric_test.py
+++ b/bluecellulab/validation/parametric_test.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parametric validation test: composes protocol + measurement + criterion."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from bluecellulab.validation.base import ValidationOutcome, ValidationTest
+from bluecellulab.validation.criterion import Criterion
+from bluecellulab.validation.measurement import Measurement
+from bluecellulab.validation.plotting import plot_trace
+from bluecellulab.validation.protocol import Protocol
+
+
+@dataclass
+class ParametricValidation(ValidationTest):
+    """A composable validation test built from protocol + measurement + criterion.
+
+    This class allows users to define custom validations by combining:
+    - A Protocol (how to stimulate the cell)
+    - A Measurement (what to extract from the recording)
+    - A Criterion (how to judge pass/fail)
+
+    Attributes:
+        validation_name: Stable identifier for this validation.
+        protocol: The stimulation protocol to execute.
+        measurement: The measurement to extract from the recording.
+        criterion: The pass/fail criterion to apply to the measurement.
+        figure_filename: Optional filename for the output trace plot.
+    """
+
+    validation_name: str
+    protocol: Protocol
+    measurement: Measurement
+    criterion: Criterion
+    figure_filename: str = "validation.pdf"
+
+    @property
+    def name(self) -> str:
+        return self.validation_name
+
+    def run(self, template_params, rheobase: float, out_dir: Path) -> ValidationOutcome:
+        """Execute protocol, extract measurement, evaluate criterion.
+
+        Args:
+            template_params: BlueCelluLab TemplateParams for creating the cell.
+            rheobase: The rheobase (threshold) current in nA.
+            out_dir: Directory to write output figures.
+
+        Returns:
+            A ValidationOutcome with the test result.
+        """
+        out_dir = Path(out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # 1. Execute protocol
+        recording = self.protocol.execute(template_params, rheobase)
+
+        # 2. Extract measurement
+        value = self.measurement.extract(
+            recording,
+            stim_start=self.protocol.stim_start,
+            stim_end=self.protocol.stim_end,
+        )
+
+        # 3. Evaluate criterion
+        if value is None:
+            passed = False
+            details = (
+                "Validation failed: measurement could not be extracted "
+                "(feature returned None)."
+            )
+        else:
+            passed = self.criterion.evaluate(value)
+            details = self.criterion.describe(value)
+
+        # 4. Generate figure
+        figures = []
+        fig_path = plot_trace(
+            recording,
+            out_dir,
+            fname=self.figure_filename,
+            title=f"{self.name} - {self.protocol.__class__.__name__}",
+        )
+        figures.append(fig_path)
+
+        return ValidationOutcome(
+            name=self.name,
+            passed=passed,
+            details=details,
+            figures=figures,
+        )

--- a/bluecellulab/validation/plotting.py
+++ b/bluecellulab/validation/plotting.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plotting utilities for validation results."""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def plot_trace(recording, out_dir, fname, title, plot_current=True):
+    """Plot a trace with input current given a recording.
+
+    Args:
+        recording: A Recording object with time, voltage, and current attributes.
+        out_dir: Output directory for the figure.
+        fname: Filename for the saved figure.
+        title: Title for the plot.
+        plot_current: Whether to overlay the stimulus current.
+
+    Returns:
+        Path to the saved figure.
+    """
+    out_dir = Path(out_dir)
+    outpath = out_dir / fname
+    fig, ax1 = plt.subplots(figsize=(10, 6))
+    plt.plot(recording.time, recording.voltage, color="black")
+    if plot_current:
+        current_axis = ax1.twinx()
+        current_axis.plot(recording.time, recording.current, color="gray", alpha=0.6)
+        current_axis.set_ylabel("Stimulus Current [nA]")
+    if title:
+        fig.suptitle(title)
+    ax1.set_xlabel("Time [ms]")
+    ax1.set_ylabel("Voltage [mV]")
+    fig.tight_layout()
+    fig.savefig(outpath)
+    plt.close(fig)
+
+    return outpath

--- a/bluecellulab/validation/protocol.py
+++ b/bluecellulab/validation/protocol.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Open Brain Institute
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Protocols define how to stimulate a cell and obtain a recording."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from bluecellulab.analysis.inject_sequence import Recording, run_stimulus
+from bluecellulab.stimulus.factory import IDRestTimings, StimulusFactory
+
+
+class Protocol(ABC):
+    """Abstract base for stimulation protocols.
+
+    A protocol injects a stimulus into a cell and returns a recording.
+    It also provides timing information for feature extraction.
+    """
+
+    @abstractmethod
+    def execute(self, template_params, rheobase: float) -> Recording:
+        """Run the protocol on a cell.
+
+        Args:
+            template_params: BlueCelluLab TemplateParams for creating the cell.
+            rheobase: The rheobase (threshold) current in nA.
+
+        Returns:
+            A Recording with time, voltage, current, and optionally spikes.
+        """
+
+    @property
+    @abstractmethod
+    def stim_start(self) -> float:
+        """Stimulus onset time in ms."""
+
+    @property
+    @abstractmethod
+    def stim_end(self) -> float:
+        """Stimulus offset time in ms."""
+
+
+@dataclass
+class StepProtocol(Protocol):
+    """IDRest-style step current injection at a percentage of rheobase.
+
+    Attributes:
+        threshold_percentage: Percentage of rheobase to inject (e.g. 130 = 130%).
+        dt: Time step for the stimulus waveform in ms.
+        section: Section to inject into.
+        segment: Segment position along the section (0.0 to 1.0).
+        add_hypamp: Whether to add the holding current.
+    """
+
+    threshold_percentage: float = 130.0
+    dt: float = 1.0
+    section: str = "soma[0]"
+    segment: float = 0.5
+    add_hypamp: bool = True
+
+    @property
+    def stim_start(self) -> float:
+        return IDRestTimings.PRE_DELAY.value
+
+    @property
+    def stim_end(self) -> float:
+        return IDRestTimings.PRE_DELAY.value + IDRestTimings.DURATION.value
+
+    def execute(self, template_params, rheobase: float) -> Recording:
+        """Inject a step current and record the response."""
+        stim_factory = StimulusFactory(dt=self.dt)
+        stimulus = stim_factory.idrest(
+            threshold_current=rheobase,
+            threshold_percentage=self.threshold_percentage,
+        )
+        return run_stimulus(
+            template_params,
+            stimulus,
+            self.section,
+            self.segment,
+            add_hypamp=self.add_hypamp,
+        )

--- a/bluecellulab/validation/protocol.py
+++ b/bluecellulab/validation/protocol.py
@@ -15,7 +15,7 @@
 """Protocols define how to stimulate a cell and obtain a recording."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from bluecellulab.analysis.inject_sequence import Recording, run_stimulus
 from bluecellulab.stimulus.factory import IDRestTimings, StimulusFactory
@@ -87,6 +87,99 @@ class StepProtocol(Protocol):
         return run_stimulus(
             template_params,
             stimulus,
+            self.section,
+            self.segment,
+            add_hypamp=self.add_hypamp,
+        )
+
+
+@dataclass
+class SequenceProtocol(Protocol):
+    """Multi-phase stimulus protocol composed of sequential steps.
+
+    Each phase is defined by a duration and amplitude (as percentage of rheobase).
+    Phases are concatenated in order with a configurable pre-delay and post-delay.
+
+    This enables protocols like rebound bursting (hold -> hyperpolarize -> release)
+    or any custom multi-step stimulation sequence.
+
+    Attributes:
+        phases: List of (duration_ms, threshold_percentage) tuples. Each phase is
+            a step at the given percentage of rheobase for the given duration.
+        pre_delay: Delay before the first phase in ms.
+        post_delay: Delay after the last phase in ms.
+        dt: Time step for the stimulus waveform in ms.
+        section: Section to inject into.
+        segment: Segment position along the section (0.0 to 1.0).
+        add_hypamp: Whether to add the holding current.
+
+    Example:
+        Rebound burst protocol (hold 250ms, hyperpolarize 500ms at -200%, release 500ms):
+
+        >>> protocol = SequenceProtocol(
+        ...     phases=[(500.0, -200.0), (500.0, 0.0)],
+        ...     pre_delay=250.0,
+        ...     post_delay=250.0,
+        ... )
+    """
+
+    phases: list[tuple[float, float]] = field(default_factory=lambda: [(1350.0, 130.0)])
+    pre_delay: float = 250.0
+    post_delay: float = 250.0
+    dt: float = 1.0
+    section: str = "soma[0]"
+    segment: float = 0.5
+    add_hypamp: bool = True
+
+    @property
+    def stim_start(self) -> float:
+        return self.pre_delay
+
+    @property
+    def stim_end(self) -> float:
+        total_duration = sum(duration for duration, _ in self.phases)
+        return self.pre_delay + total_duration
+
+    def execute(self, template_params, rheobase: float) -> Recording:
+        """Build a multi-phase stimulus and record the response."""
+        stim_factory = StimulusFactory(dt=self.dt)
+
+        # Build the first phase with the pre_delay
+        first_duration, first_pct = self.phases[0]
+        first_amplitude = rheobase * first_pct / 100.0
+        combined = stim_factory.step(
+            pre_delay=self.pre_delay,
+            duration=first_duration,
+            post_delay=0.0,
+            amplitude=first_amplitude,
+        )
+
+        # Add subsequent phases
+        for i, (duration, pct) in enumerate(self.phases[1:], start=1):
+            amplitude = rheobase * pct / 100.0
+            is_last = i == len(self.phases) - 1
+            post = self.post_delay if is_last else 0.0
+            phase_stimulus = stim_factory.step(
+                pre_delay=0.0,
+                duration=duration,
+                post_delay=post,
+                amplitude=amplitude,
+            )
+            combined = combined + phase_stimulus
+
+        # If only one phase, append the post_delay as a zero-amplitude step
+        if len(self.phases) == 1:
+            post_stimulus = stim_factory.step(
+                pre_delay=0.0,
+                duration=self.post_delay,
+                post_delay=0.0,
+                amplitude=0.0,
+            )
+            combined = combined + post_stimulus
+
+        return run_stimulus(
+            template_params,
+            combined,
             self.section,
             self.segment,
             add_hypamp=self.add_hypamp,

--- a/tests/test_validation/test_parametric_framework.py
+++ b/tests/test_validation/test_parametric_framework.py
@@ -1,0 +1,279 @@
+"""Unit tests for the parametric validation framework."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from bluecellulab.validation.base import ValidationOutcome
+from bluecellulab.validation.criterion import GreaterThan
+from bluecellulab.validation.measurement import EfelMeasurement
+from bluecellulab.validation.parametric_test import ParametricValidation
+from bluecellulab.validation.plotting import plot_trace
+from bluecellulab.validation.protocol import StepProtocol
+
+
+class TestValidationOutcome:
+    def test_creation_minimal(self):
+        outcome = ValidationOutcome(name="test", passed=True, details="ok")
+        assert outcome.name == "test"
+        assert outcome.passed is True
+        assert outcome.details == "ok"
+        assert outcome.figures == []
+
+    def test_creation_with_figures(self, tmp_path):
+        figs = [tmp_path / "fig1.pdf", tmp_path / "fig2.png"]
+        outcome = ValidationOutcome(name="test", passed=False, details="failed", figures=figs)
+        assert outcome.figures == figs
+        assert outcome.passed is False
+
+    def test_figures_default_is_not_shared(self):
+        """Ensure each instance gets its own figures list."""
+        o1 = ValidationOutcome(name="a", passed=True, details="")
+        o2 = ValidationOutcome(name="b", passed=True, details="")
+        o1.figures.append(Path("x"))
+        assert o2.figures == []
+
+
+class TestGreaterThan:
+    def test_passes_when_above(self):
+        c = GreaterThan(threshold=5.0)
+        assert c.evaluate(6) is True
+
+    def test_fails_when_equal(self):
+        c = GreaterThan(threshold=5.0)
+        assert c.evaluate(5) is False
+
+    def test_fails_when_below(self):
+        c = GreaterThan(threshold=5.0)
+        assert c.evaluate(3) is False
+
+    def test_describe_pass(self):
+        c = GreaterThan(threshold=0)
+        desc = c.describe(5)
+        assert "5" in desc
+        assert "greater than" in desc
+
+    def test_describe_fail(self):
+        c = GreaterThan(threshold=10)
+        desc = c.describe(3)
+        assert "not greater than" in desc
+
+
+class TestEfelMeasurement:
+    @patch("bluecellulab.validation.measurement.efel.get_feature_values")
+    def test_extract_scalar_feature(self, mock_efel):
+        mock_efel.return_value = [{"Spikecount": [5]}]
+        m = EfelMeasurement(feature_name="Spikecount")
+        recording = MagicMock()
+        recording.time = np.arange(0, 100, 1.0)
+        recording.voltage = np.full(100, -70.0)
+        value = m.extract(recording, stim_start=10.0, stim_end=90.0)
+        assert value == 5
+        mock_efel.assert_called_once()
+
+    @patch("bluecellulab.validation.measurement.efel.get_feature_values")
+    def test_extract_returns_none_when_feature_is_none(self, mock_efel):
+        mock_efel.return_value = [{"Spikecount": None}]
+        m = EfelMeasurement(feature_name="Spikecount")
+        recording = MagicMock()
+        recording.time = np.arange(0, 100, 1.0)
+        recording.voltage = np.full(100, -70.0)
+        value = m.extract(recording, stim_start=10.0, stim_end=90.0)
+        assert value is None
+
+    @patch("bluecellulab.validation.measurement.efel.get_feature_values")
+    def test_extract_returns_none_when_feature_is_empty(self, mock_efel):
+        mock_efel.return_value = [{"Spikecount": []}]
+        m = EfelMeasurement(feature_name="Spikecount")
+        recording = MagicMock()
+        recording.time = np.arange(0, 100, 1.0)
+        recording.voltage = np.full(100, -70.0)
+        value = m.extract(recording, stim_start=10.0, stim_end=90.0)
+        assert value is None
+
+    @patch("bluecellulab.validation.measurement.efel.get_feature_values")
+    def test_extract_multi_value_feature(self, mock_efel):
+        mock_efel.return_value = [{"peak_time": [10.5, 20.3, 30.1]}]
+        m = EfelMeasurement(feature_name="peak_time")
+        recording = MagicMock()
+        recording.time = np.arange(0, 100, 1.0)
+        recording.voltage = np.full(100, -70.0)
+        value = m.extract(recording, stim_start=10.0, stim_end=90.0)
+        assert value == [10.5, 20.3, 30.1]
+
+
+class TestStepProtocol:
+    def test_default_values(self):
+        p = StepProtocol()
+        assert p.threshold_percentage == 130.0
+        assert p.dt == 1.0
+        assert p.section == "soma[0]"
+        assert p.segment == 0.5
+        assert p.add_hypamp is True
+
+    def test_stim_timing(self):
+        p = StepProtocol()
+        assert p.stim_start == 250.0
+        assert p.stim_end == 1600.0
+
+    def test_custom_parameters(self):
+        p = StepProtocol(
+            threshold_percentage=200.0,
+            dt=0.5,
+            section="axon[0]",
+            segment=0.1,
+            add_hypamp=False,
+        )
+        assert p.threshold_percentage == 200.0
+        assert p.dt == 0.5
+        assert p.section == "axon[0]"
+        assert p.segment == 0.1
+        assert p.add_hypamp is False
+
+    @patch("bluecellulab.validation.protocol.run_stimulus")
+    @patch("bluecellulab.validation.protocol.StimulusFactory")
+    def test_execute_calls_stimulus_factory(self, mock_factory_cls, mock_run):
+        mock_factory = MagicMock()
+        mock_factory_cls.return_value = mock_factory
+        mock_stimulus = MagicMock()
+        mock_factory.idrest.return_value = mock_stimulus
+        mock_recording = MagicMock()
+        mock_run.return_value = mock_recording
+
+        p = StepProtocol(threshold_percentage=150.0)
+        result = p.execute("template_params", 0.5)
+
+        mock_factory_cls.assert_called_once_with(dt=1.0)
+        mock_factory.idrest.assert_called_once_with(
+            threshold_current=0.5, threshold_percentage=150.0
+        )
+        mock_run.assert_called_once_with(
+            "template_params", mock_stimulus, "soma[0]", 0.5, add_hypamp=True
+        )
+        assert result == mock_recording
+
+
+class TestParametricValidation:
+    @patch("bluecellulab.validation.parametric_test.plot_trace")
+    def test_run_passes(self, mock_plot, tmp_path):
+        mock_plot.return_value = tmp_path / "fig.pdf"
+
+        protocol = MagicMock()
+        protocol.execute.return_value = MagicMock()
+        protocol.stim_start = 250.0
+        protocol.stim_end = 1600.0
+        protocol.__class__.__name__ = "StepProtocol"
+
+        measurement = MagicMock()
+        measurement.extract.return_value = 5
+
+        criterion = MagicMock()
+        criterion.evaluate.return_value = True
+        criterion.describe.return_value = "Value 5 is greater than 0."
+
+        pv = ParametricValidation(
+            validation_name="Test Validation",
+            protocol=protocol,
+            measurement=measurement,
+            criterion=criterion,
+            figure_filename="test.pdf",
+        )
+
+        outcome = pv.run("tparams", 1.0, tmp_path)
+
+        assert outcome.name == "Test Validation"
+        assert outcome.passed is True
+        assert outcome.details == "Value 5 is greater than 0."
+        assert len(outcome.figures) == 1
+
+        protocol.execute.assert_called_once_with("tparams", 1.0)
+        measurement.extract.assert_called_once()
+        criterion.evaluate.assert_called_once_with(5)
+
+    @patch("bluecellulab.validation.parametric_test.plot_trace")
+    def test_run_fails(self, mock_plot, tmp_path):
+        mock_plot.return_value = tmp_path / "fig.pdf"
+
+        protocol = MagicMock()
+        protocol.execute.return_value = MagicMock()
+        protocol.stim_start = 250.0
+        protocol.stim_end = 1600.0
+        protocol.__class__.__name__ = "StepProtocol"
+
+        measurement = MagicMock()
+        measurement.extract.return_value = 0
+
+        criterion = MagicMock()
+        criterion.evaluate.return_value = False
+        criterion.describe.return_value = "Value 0 is not greater than 0."
+
+        pv = ParametricValidation(
+            validation_name="Fail Test",
+            protocol=protocol,
+            measurement=measurement,
+            criterion=criterion,
+        )
+
+        outcome = pv.run("tparams", 1.0, tmp_path)
+        assert outcome.passed is False
+        assert "not greater than" in outcome.details
+
+    @patch("bluecellulab.validation.parametric_test.plot_trace")
+    def test_run_with_none_measurement(self, mock_plot, tmp_path):
+        mock_plot.return_value = tmp_path / "fig.pdf"
+
+        protocol = MagicMock()
+        protocol.execute.return_value = MagicMock()
+        protocol.stim_start = 250.0
+        protocol.stim_end = 1600.0
+        protocol.__class__.__name__ = "StepProtocol"
+
+        measurement = MagicMock()
+        measurement.extract.return_value = None
+
+        criterion = MagicMock()
+
+        pv = ParametricValidation(
+            validation_name="None Test",
+            protocol=protocol,
+            measurement=measurement,
+            criterion=criterion,
+        )
+
+        outcome = pv.run("tparams", 1.0, tmp_path)
+        assert outcome.passed is False
+        assert "could not be extracted" in outcome.details
+        criterion.evaluate.assert_not_called()
+
+    def test_name_property(self):
+        pv = ParametricValidation(
+            validation_name="My Name",
+            protocol=MagicMock(),
+            measurement=MagicMock(),
+            criterion=MagicMock(),
+        )
+        assert pv.name == "My Name"
+
+
+class TestPlotTrace:
+    def test_creates_figure_file(self, tmp_path):
+        recording = MagicMock()
+        recording.time = np.arange(0, 100, 1.0)
+        recording.voltage = np.random.randn(100) * 10 - 70
+        recording.current = np.full(100, 0.5)
+
+        outpath = plot_trace(recording, tmp_path, "test.pdf", "Test Title")
+        assert outpath.exists()
+        assert outpath.name == "test.pdf"
+
+    def test_creates_figure_without_current(self, tmp_path):
+        recording = MagicMock()
+        recording.time = np.arange(0, 100, 1.0)
+        recording.voltage = np.random.randn(100) * 10 - 70
+        recording.current = np.full(100, 0.5)
+
+        outpath = plot_trace(
+            recording, tmp_path, "no_current.pdf", "No Current", plot_current=False
+        )
+        assert outpath.exists()


### PR DESCRIPTION
## Summary

Introduces a composable, parametric validation framework alongside the existing `validation.py`. Users can define custom electrophysiology validations by composing Protocol + Measurement + Criterion — without modifying BlueCelluLab source code.

## Motivation

The current `validation.py` contains hardcoded validation tests (fixed protocols, fixed eFEL features, fixed pass/fail logic). Adding a new validation requires writing a new function from scratch. This framework makes it trivial to define parametric validations that can be configured at runtime.

## What's added

```
bluecellulab/validation/
├── __init__.py          # Package exports
├── base.py              # ValidationOutcome dataclass + ValidationTest ABC
├── protocol.py          # Protocol ABC + StepProtocol (IDRest at X% rheobase)
├── measurement.py       # Measurement ABC + EfelMeasurement (any eFEL feature)
├── criterion.py         # Criterion ABC + GreaterThan (numpy-array-safe)
├── parametric_test.py   # ParametricValidation: composes protocol+measurement+criterion
├── plotting.py          # plot_trace utility (extracted from validation.py)
└── validation.py        # UNCHANGED — backward compatible
```

## Usage

```python
from bluecellulab.validation import (
    ParametricValidation, StepProtocol, EfelMeasurement, GreaterThan,
)

# Define a custom validation: spike count > 0 at 130% rheobase
test = ParametricValidation(
    validation_name="Spiking Validation",
    protocol=StepProtocol(threshold_percentage=130.0),
    measurement=EfelMeasurement(feature_name="Spikecount"),
    criterion=GreaterThan(threshold=0),
)

outcome = test.run(cell.template_params, rheobase, out_dir)
# outcome.name, outcome.passed, outcome.details, outcome.figures
```

## Design decisions

- **Existing `validation.py` is untouched** — no breaking changes
- **numpy-safe criteria** — `GreaterThan` handles both scalar and array-valued measurements (e.g., AP_amplitude returns one value per spike)
- **Composable** — any combination of protocol, measurement, and criterion can be assembled without subclassing
- **Extensible** — new protocols, measurements, and criteria can be added independently